### PR TITLE
WMS Feature info plugin for MapStore.

### DIFF
--- a/mapcomposer/app/static/externals/gxp/src/script/plugins/FeatureEditorGrid.js
+++ b/mapcomposer/app/static/externals/gxp/src/script/plugins/FeatureEditorGrid.js
@@ -1,0 +1,265 @@
+/**
+ * Copyright (c) 2008-2012 The Open Planning Project
+ * 
+ * Published under the GPL license.
+ * See https://github.com/opengeo/gxp/raw/master/license.txt for the full text
+ * of the license.
+ */
+
+/**
+ * @requires plugins/SchemaAnnotations.js
+ */
+
+/** api: (define)
+ *  module = gxp.plugins
+ *  class = FeatureEditorGrid
+ *  base_link = `Ext.grid.PropertyGrid <http://extjs.com/deploy/dev/docs/?class=Ext.grid.PropertyGrid>`_
+ */
+
+Ext.namespace("gxp.plugins");
+
+/** api: constructor
+ *  .. class:: FeatureEditorGrid(config)
+ *
+ *    Plugin for editing a feature in a property grid.
+ */
+gxp.plugins.FeatureEditorGrid = Ext.extend(Ext.grid.PropertyGrid, {
+
+    /** api: ptype = gxp_editorgrid */
+    ptype: "gxp_editorgrid",
+
+    /** api: xtype = gxp_editorgrid */
+    xtype: "gxp_editorgrid",
+
+    /** api: config[feature]
+     *  ``OpenLayers.Feature.Vector`` The feature being edited/displayed.
+     */
+    feature: null,
+
+    /** api: config[schema]
+     *  ``GeoExt.data.AttributeStore`` Optional. If provided, available
+     *  feature attributes will be determined from the schema instead of using
+     *  the attributes that the feature has currently set.
+     */
+    schema: null,
+
+    /** api: config[fields]
+     *  ``Array``
+     *  List of field config names corresponding to feature attributes.  If
+     *  not provided, fields will be derived from attributes. If provided,
+     *  the field order from this list will be used, and fields missing in the
+     *  list will be excluded.
+     */
+    fields: null,
+
+    /** api: config[excludeFields]
+     *  ``Array`` Optional list of field names (case sensitive) that are to be
+     *  excluded from the editor plugin.
+     */
+    excludeFields: null,
+
+    /** api: config[propertyNames]
+     *  ``Object`` Property name/display name pairs. If specified, the display
+     *  name will be shown in the name column instead of the property name.
+     */
+    propertyNames: null,
+
+    /** api: config[readOnly]
+     *  ``Boolean`` Set to true to disable editing. Default is false.
+     */
+    readOnly: null,
+
+    /** private: property[border]
+     *  ``Boolean`` Do not show a border.
+     */
+    border: false,
+
+    /** private: method[initComponent]
+     */
+    initComponent : function() {
+        if (!this.dateFormat) {
+            this.dateFormat = Ext.form.DateField.prototype.format;
+        }
+        if (!this.timeFormat) {
+            this.timeFormat = Ext.form.TimeField.prototype.format;
+        }
+        this.customRenderers = this.customRenderers || {};
+        this.customEditors = this.customEditors || {};
+        var feature = this.feature,
+            attributes;
+        if (this.fields) {
+            // determine the order of attributes
+            attributes = {};
+            for (var i=0,ii=this.fields.length; i<ii; ++i) {
+                attributes[this.fields[i]] = feature.attributes[this.fields[i]];
+            }
+        } else {
+            attributes = feature.attributes;
+        }
+        if (!this.excludeFields) {
+            this.excludeFields = [];
+        }
+
+        if(this.schema) {
+            var ucFields = this.fields ?
+                this.fields.join(",").toUpperCase().split(",") : [];
+            this.schema.each(function(r) {
+                var type = r.get("type");
+                if (type.match(/^[^:]*:?((Multi)?(Point|Line|Polygon|Curve|Surface|Geometry))/)) {
+                    // exclude gml geometries
+                    return;
+                }
+                var name = r.get("name");
+                if (this.fields) {
+                    if (ucFields.indexOf(name.toUpperCase()) == -1) {
+                        this.excludeFields.push(name);
+                    }
+                }
+                var value = feature.attributes[name];
+                var fieldCfg = GeoExt.form.recordToField(r);
+                var annotations = this.getAnnotationsFromSchema(r);
+                if (annotations && annotations.label) {
+                    this.propertyNames = this.propertyNames || {};
+                    this.propertyNames[name] = annotations.label;
+                }
+                var listeners;
+                if (typeof value == "string") {
+                    var format;
+                    switch(type.split(":").pop()) {
+                        case "date":
+                            format = this.dateFormat;
+                            fieldCfg.editable = false;
+                            break;
+                        case "dateTime":
+                            if (!format) {
+                                format = this.dateFormat + " " + this.timeFormat;
+                                // make dateTime fields editable because the
+                                // date picker does not allow to edit time
+                                fieldCfg.editable = true;
+                            }
+                            fieldCfg.format = format;
+                            //TODO When http://trac.osgeo.org/openlayers/ticket/3131
+                            // is resolved, remove the listeners assignment below
+                            listeners = {
+                                "startedit": function(el, value) {
+                                    if (!(value instanceof Date)) {
+                                        var date = Date.parseDate(value.replace(/Z$/, ""), "c");
+                                        if (date) {
+                                            this.setValue(date);
+                                        }
+                                    }
+                                }
+                            };
+                            this.customRenderers[name] = (function() {
+                                return function(value) {
+                                    //TODO When http://trac.osgeo.org/openlayers/ticket/3131
+                                    // is resolved, change the 5 lines below to
+                                    // return value.format(format);
+                                    var date = value;
+                                    if (typeof value == "string") {
+                                        date = Date.parseDate(value.replace(/Z$/, ""), "c");
+                                    }
+                                    return date ? date.format(format) : value;
+                                };
+                            })();
+                            break;
+                        case "boolean":
+                            listeners = {
+                                "startedit": function(el, value) {
+                                    this.setValue(Boolean(value));
+                                }
+                            };
+                            break;
+                        default:
+                            break;
+                    }
+                }
+                this.customEditors[name] = new Ext.grid.GridEditor({
+                    field: Ext.create(fieldCfg),
+                    listeners: listeners
+                });
+                attributes[name] = value;
+            }, this);
+            feature.attributes = attributes;
+        }
+        this.source = attributes;
+        var ucExcludeFields = this.excludeFields.length ?
+            this.excludeFields.join(",").toUpperCase().split(",") : [];
+        this.viewConfig = {
+            forceFit: true,
+            getRowClass: function(record) {
+                if (ucExcludeFields.indexOf(record.get("name").toUpperCase()) !== -1) {
+                    return "x-hide-nosize";
+                }
+            }
+        };
+        this.listeners = {
+            "beforeedit": function() {
+                return this.featureEditor && this.featureEditor.editing;
+            },
+            "propertychange": function() {
+                if (this.featureEditor) {
+                    this.featureEditor.setFeatureState(this.featureEditor.getDirtyState());
+                }
+            },
+            scope: this
+        };
+        //TODO This is a workaround for maintaining the order of the
+        // feature attributes. Decide if this should be handled in
+        // another way.
+        var origSort = Ext.data.Store.prototype.sort;
+        Ext.data.Store.prototype.sort = function() {};
+        gxp.plugins.FeatureEditorGrid.superclass.initComponent.apply(this, arguments);
+        Ext.data.Store.prototype.sort = origSort;
+
+        /**
+         * TODO: This is a workaround for getting attributes with undefined
+         * values to show up in the property grid.  Decide if this should be 
+         * handled in another way.
+         */
+        this.propStore.isEditableValue = function() {return true;};
+    },
+
+    /** private: method[init]
+     *
+     *  :arg target: ``gxp.FeatureEditPopup`` The feature edit popup 
+     *  initializing this plugin.
+     */
+    init: function(target) {
+        this.featureEditor = target;
+        this.featureEditor.on("canceledit", this.onCancelEdit, this);
+        this.featureEditor.add(this);
+        this.featureEditor.doLayout();
+    },
+
+    /** private: method[destroy]
+     *  Clean up.
+     */
+    destroy: function() {
+        if (this.featureEditor) {
+            this.featureEditor.un("canceledit", this.onCancelEdit, this);
+            this.featureEditor = null;
+        }
+        gxp.plugins.FeatureEditorGrid.superclass.destroy.call(this);
+    },
+
+    /** private: method[onCancelEdit]
+     *  :arg panel: ``gxp.FeatureEditPopup``
+     *  :arg feature: ``OpenLayers.Feature.Vector``
+     *
+     *  When editing is cancelled, set the source of this property grid
+     *  back to the supplied feature.
+     */
+    onCancelEdit: function(panel, feature) {
+        if (feature) {
+            this.setSource(feature.attributes);
+        }
+    }
+
+});
+
+// use the schema annotations module
+Ext.override(gxp.plugins.FeatureEditorGrid, gxp.plugins.SchemaAnnotations);
+
+Ext.preg(gxp.plugins.FeatureEditorGrid.prototype.ptype, gxp.plugins.FeatureEditorGrid);
+Ext.reg(gxp.plugins.FeatureEditorGrid.prototype.xtype, gxp.plugins.FeatureEditorGrid);

--- a/mapcomposer/app/static/externals/gxp/src/script/plugins/FormFieldHelp.js
+++ b/mapcomposer/app/static/externals/gxp/src/script/plugins/FormFieldHelp.js
@@ -1,0 +1,87 @@
+/**
+ * Copyright (c) 2008-2012 The Open Planning Project
+ * 
+ * Published under the GPL license.
+ * See https://github.com/opengeo/gxp/raw/master/license.txt for the full text
+ * of the license.
+ */
+
+/** api: (define)
+ *  module = gxp.plugins
+ *  class = FormFieldHelp
+ */
+
+Ext.namespace("gxp.plugins");
+
+/** api: constructor
+ *  .. class:: FormFieldHelp(config)
+ *
+ *    Plugin for showing a help text when hovering over a form field.
+ *    Uses an Ext.QuickTip.
+ */
+/** api: example
+ *    The code example below shows how to use this plugin with a form field:
+ *
+ *    .. code-block:: javascript
+ *
+ *      var field = new Ext.form.TextField({
+ *          name: 'foo',
+ *          value: 'bar',
+ *          plugins: [{
+ *              ptype: 'gxp_formfieldhelp',
+ *              helpText: 'This is the help text for my form field'
+ *          }]
+ *      });
+ */
+gxp.plugins.FormFieldHelp = Ext.extend(Object, {
+
+    /** api: ptype = gxp_formfieldhelp */
+    ptype: 'gxp_formfieldhelp',
+
+    /** api: config[helpText]
+     *  ``String`` The help text to show.
+     */
+    helpText: null,
+
+    /** api: config[dismissDelay]
+     *  ``Integer`` How long before the quick tip should disappear.
+     *  Defaults to 5 seconds.
+     */
+    dismissDelay: 5000,
+
+    /** private: method[constructor]
+     */
+    constructor: function(config) {
+        Ext.apply(this, config);
+    },
+
+    /** private: method[init]
+     *
+     *  :arg target: ``Ext.form.Field`` The form field initializing this 
+     *  plugin.
+     */
+    init: function(target){
+        this.target = target;
+        target.on('render', this.showHelp, this);
+    },
+
+    /** private: method[showHelp]
+     *  Show the help popup for the field. Show it on the associated label if
+     *  present, with a fallback to the form element itself.
+     */
+    showHelp: function() {
+        var target;
+        if (this.target.label) {
+            target = this.target.label;
+        } else {
+            target = this.target.getEl();
+        }
+        Ext.QuickTips.register({
+            target: target, 
+            dismissDelay: this.dismissDelay,
+            text: this.helpText
+        });
+    }
+});
+
+Ext.preg(gxp.plugins.FormFieldHelp.prototype.ptype, gxp.plugins.FormFieldHelp);

--- a/mapcomposer/app/static/externals/gxp/src/script/plugins/SchemaAnnotations.js
+++ b/mapcomposer/app/static/externals/gxp/src/script/plugins/SchemaAnnotations.js
@@ -1,0 +1,76 @@
+/**
+ * Copyright (c) 2008-2012 The Open Planning Project
+ * 
+ * Published under the GPL license.
+ * See https://github.com/opengeo/gxp/raw/master/license.txt for the full text
+ * of the license.
+ */
+
+/** api: (define)
+ *  module = gxp.plugins
+ *  class = FormFieldHelp
+ */
+
+Ext.namespace("gxp.plugins");
+
+/** api: constructor
+ *  .. class:: SchemaAnnotations
+ *
+ *    Module for getting annotations from the WFS DescribeFeatureType schema.
+ *    This is currently used in gxp.plugins.FeatureEditorForm and
+ *    gxp.plugins.FeatureEditorGrid.
+ *   
+ *    The WFS needs to provide xsd:annotation in the XML Schema which is 
+ *    reported back on a WFS DescribeFeatureType request. An example is:
+ *  
+ *    .. code-block:: xml
+ *
+ *      <xsd:element maxOccurs="1" minOccurs="0" name="PERSONS" nillable="true" type="xsd:double">
+ *        <xsd:annotation>
+ *          <xsd:appinfo>{"title":{"en":"Population"}}</xsd:appinfo>
+ *          <xsd:documentation xml:lang="en">
+ *            Number of persons living in the state
+ *          </xsd:documentation>
+ *        </xsd:annotation>
+ *      </xsd:element>
+ *
+ *    To use this module simply use Ext.override in your class, and use the 
+ *    getAnnotationsFromSchema function on a record from the attribute store.
+ *
+ *    .. code-block:: javascript
+ *
+ *    Ext.override(gxp.plugins.YourPlugin, gxp.plugins.SchemaAnnotations);
+ *
+ */
+gxp.plugins.SchemaAnnotations = {
+
+    /** api: method[getAnnotationsFromSchema]
+     *
+     *  :arg r: ``Ext.data.Record`` a record from the AttributeStore
+     *  :returns: ``Object`` Object with label and helpText properties or
+     *  null if no annotation was found.
+     */
+    getAnnotationsFromSchema: function(r) {
+        var result = null;
+        var annotation = r.get('annotation');
+        if (annotation !== undefined) {
+            result = {};
+            var lang = GeoExt.Lang.locale.split("-").shift();
+            var i, ii;
+            for (i=0, ii=annotation.appinfo.length; i<ii; ++i) {
+                var json = Ext.decode(annotation.appinfo[i]);
+                if (json.title && json.title[lang]) {
+                    result.label = json.title[lang];
+                    break;
+                }
+            }
+            for (i=0, ii=annotation.documentation.length; i<ii; ++i) {
+                if (annotation.documentation[i].lang === lang) {
+                    result.helpText = annotation.documentation[i].textContent;
+                    break;
+                }
+            }
+        }
+        return result;
+    }
+};

--- a/mapcomposer/app/static/script/app/GeoExplorer/Composer.js
+++ b/mapcomposer/app/static/script/app/GeoExplorer/Composer.js
@@ -118,7 +118,7 @@ GeoExplorer.Composer = Ext.extend(GeoExplorer, {
 		        }, {
 		            actions: ["-"], actionTarget: "paneltbar"
 		        }, {
-		            ptype: "gxp_wmsgetfeatureinfo_menu", 
+		            ptype: "ms_wmsgetfeatureinfo_menu", 
 					toggleGroup: this.toggleGroup,
 					useTabPanel: true,
 		            actionTarget: {target: "paneltbar", index: 20}

--- a/mapcomposer/app/static/script/ux/MapStore/plugins/WMSGetFeatureInfoMenu.js
+++ b/mapcomposer/app/static/script/ux/MapStore/plugins/WMSGetFeatureInfoMenu.js
@@ -1,0 +1,465 @@
+
+/*
+ * WMSGetFeatureInfoMenu.js Copyright (C) 2013 This file is part of MapStore project.
+ * Published under the GPLv3. 
+ * See https://raw.github.com/geosolutions-it/mapstore/master/license.txt for the full text license.
+ * 
+ * Authors: Alejandro Diaz Torres (mailto:aledt84@gmail.com)
+ */
+
+/**
+ * @required  plugins/WMSGetFeatureInfoMenu.js
+ * @required  MapStore/plugins/WMSGetFeatureInfoDialog.js
+ */
+
+/** api: (define)
+ *  module = MapStore.plugins
+ *  class = WMSGetFeatureInfoMenu
+ */
+Ext.namespace("MapStore.plugins");
+
+/**
+ * Class: MapStore.plugins.WMSGetFeatureInfoMenu
+ * 
+ * WMSGetFeatureInfoMenu custom tool for MapStore
+ * 
+ */
+MapStore.plugins.WMSGetFeatureInfoMenu = Ext.extend(gxp.plugins.WMSGetFeatureInfoMenu, {
+
+    /** api: ptype = ms_wmsgetfeatureinfo_menu */
+    ptype: "ms_wmsgetfeatureinfo_menu",
+
+    /** i18n **/
+    defaultGroupTitleText: "{0} [{1}]",
+     
+    /** api: method[addActions]
+     */
+    addActions: function() {
+        this.popupCache = {};
+        this.activeIndex = 0;
+        
+        var items = [new Ext.menu.CheckItem({
+            tooltip: this.infoActionTip,
+            text: this.infoActionTip,
+            iconCls: "gxp-icon-getfeatureinfo",
+            toggleGroup: this.toggleGroup,
+            group: this.toggleGroup,
+            listeners: {
+                checkchange: function(item, checked) {
+                    this.activeIndex = 0;
+                    this.button.toggle(checked);
+                    if (checked) {
+                        this.button.setIconClass(item.iconCls);
+                    }
+                    for (var i = 0, len = info.controls.length; i < len; i++){
+                    if (checked) {
+                            info.controls[i].activate();
+                        } else {
+                            info.controls[i].deactivate();
+                            
+                        }
+                    }
+                },
+                scope: this
+            }
+        }),new Ext.menu.CheckItem({
+            tooltip: this.activeActionTip,
+            text: this.activeActionTip,
+            iconCls: "gxp-icon-mouse-map",
+            
+            toggleGroup: this.toggleGroup,
+            group: this.toggleGroup,
+            allowDepress:false,
+            listeners: {
+                checkchange: function(item, checked) {
+                    this.activeIndex = 1;
+                    this.button.toggle(checked);
+                    if (checked) {
+                        this.button.setIconClass(item.iconCls);
+                    }
+                    this.toggleActiveControl(checked);
+                },
+                scope: this
+            }
+        })];
+        
+        this.button = new Ext.SplitButton({
+            iconCls: "gxp-icon-getfeatureinfo",
+            tooltip: this.measureTooltip,
+            enableToggle: true,
+            toggleGroup: this.toggleGroup,
+            allowDepress: true,
+            handler: function(button, event) {
+                if(button.pressed) {
+                    button.menu.items.itemAt(this.activeIndex).setChecked(true);
+                }
+            },
+            scope: this,
+            listeners: {
+                toggle: function(button, pressed) {
+                    // toggleGroup should handle this
+                    if(!pressed) {
+                        // Issue #178: Clear popups.
+                        this.clearPopups();
+                        button.menu.items.each(function(i) {
+                            i.setChecked(false);
+                        });
+                    }
+                },
+                render: function(button) {
+                    // toggleGroup should handle this
+                    Ext.ButtonToggleMgr.register(button);
+                },
+                scope: this
+            },
+            menu: new Ext.menu.Menu({
+                items: items
+            })
+        });
+        
+        var actions = gxp.plugins.WMSGetFeatureInfoMenu.superclass.addActions.call(this, [this.button]);
+        var infoButton = items[0];
+
+        var info = {controls: []};
+        var layersToQuery = 0;
+        
+        var updateInfo = function() {
+            var queryableLayers = this.target.mapPanel.layers.queryBy(function(x){
+                return x.get("queryable");
+            });
+
+            var map = this.target.mapPanel.map;
+            var control;
+            for (var i = 0, len = info.controls.length; i < len; i++){
+                control = info.controls[i];
+                control.deactivate();  // TODO: remove when http://trac.openlayers.org/ticket/2130 is closed
+                control.destroy();
+            }
+            
+            info.controls = [];
+            var started = false;
+            var atLeastOneResponse = false;
+            this.masking = false;
+            
+            queryableLayers.each(function(x){                
+                var l = x.getLayer();
+                
+                var vendorParams = {};
+                Ext.apply(vendorParams, x.getLayer().vendorParams || this.vendorParams || {});
+                if(!vendorParams.env || vendorParams.env.indexOf('locale:') == -1) {
+                    vendorParams.env = vendorParams.env ? vendorParams.env + ';locale:' + GeoExt.Lang.locale : 'locale:' + GeoExt.Lang.locale;
+                }
+
+                // Change info format
+                var infoFormat = x.get("infoFormat");
+                if (infoFormat === undefined) {
+                    infoFormat = this.format == "html" ? "text/html" : "application/vnd.ogc.gml";
+                }
+                
+                var control = new OpenLayers.Control.WMSGetFeatureInfo({
+                    url: l.url,
+                    queryVisible: true,
+                    map: map,
+                    layers: [x.getLayer()],
+                    infoFormat: infoFormat,
+                    vendorParams: vendorParams,
+                    eventListeners: {
+                        beforegetfeatureinfo: function(evt) {
+                            //first getFeatureInfo in chain
+                            if(!started){
+                                started= true;
+                                atLeastOneResponse=false;
+                                layersToQuery=queryableLayers.length;
+                            }
+                            
+                            if(this.loadingMask && !this.masking) {
+                                this.target.mapPanel.el.mask(this.maskMessage);
+                                this.masking = true;
+                            }
+                        },
+                        getfeatureinfo: function(evt) {
+                            layersToQuery--;
+                            //last get feature info in chain
+                            if(layersToQuery === 0) {
+                                this.unmask();
+                                started=false;
+                                
+                            }
+
+                            var title = x.get("title") || x.get("name");
+                            if (infoFormat == "text/html") {
+                                var match = evt.text.match(/<body[^>]*>([\s\S]*)<\/body>/);
+                                if (match && !match[1].match(/^\s*$/)) {
+                                    this.displayPopup(evt, title, match[1]);
+                                }
+                            } else if (infoFormat == "text/plain") {
+                                this.displayPopup(evt, title, '<pre>' + evt.text + '</pre>');
+                            } else if (evt.features && evt.features.length > 0) {
+                                this.displayPopup(evt, title, null, evt.features);
+                            // no response at all
+                            } else if(layersToQuery === 0 && !atLeastOneResponse) {
+                                Ext.Msg.show({
+                                    title: this.popupTitle,
+                                    msg: this.noDataMsg,
+                                    buttons: Ext.Msg.OK,
+                                    icon: Ext.MessageBox.WARNING
+                                });
+                            }
+                            
+                        },
+                        nogetfeatureinfo: function(evt) {
+                            layersToQuery--;                            
+                            this.unmask();                          
+                        },
+                        scope: this
+                    }
+                });
+                map.addControl(control);
+                info.controls.push(control);
+                if(infoButton.checked) {
+                    control.activate();
+                }
+            }, this);
+
+        };
+        
+        var updateInfoEvent = function() {
+            if(layersToQuery === 0) {
+                updateInfo.call(this);
+            }
+        };
+        this.target.mapPanel.layers.on("update", updateInfoEvent, this);
+        this.target.mapPanel.layers.on("add", updateInfoEvent, this);
+        this.target.mapPanel.layers.on("remove", updateInfoEvent, this);
+        
+        return actions;
+    },
+
+    /** private: method[activateActiveControl] 
+     *  activate the active control. called on tool activation
+     *  if a layer is selected, or on selectionchangeEvent
+     */
+    activateActiveControl: function(layer, title){
+        this.cleanActiveControl();
+        var tooltip;
+        var cleanup = function() {
+            if (tooltip) {
+                tooltip.destroy();
+            }  
+        };
+        
+        var vendorParams = {};
+        Ext.apply(vendorParams, layer.vendorParams || this.vendorParams || {});
+        if(!vendorParams.env || vendorParams.env.indexOf('locale:') == -1) {
+            vendorParams.env = vendorParams.env ? vendorParams.env + ';locale:' + GeoExt.Lang.locale : 'locale:' + GeoExt.Lang.locale;
+        }
+
+        var selectedLayer = this.target.mapPanel.layers.queryBy(function(x){
+            return (layer.id == x.getLayer().id) && x.get("queryable") ;
+        });
+
+        selectedLayer.each(function(x){      
+            // Change info format. Issue #91
+            var infoFormat = x.get("infoFormat");
+            if (infoFormat === undefined) {
+                infoFormat = this.format == "html" ? "text/html" : "application/vnd.ogc.gml";
+            }
+                    
+            var control = new OpenLayers.Control.WMSGetFeatureInfo({
+                title: 'Identify features by clicking',
+                layers: [layer],
+                infoFormat: infoFormat,
+                vendorParams: vendorParams,
+                hover: true,
+                queryVisible: true,
+                handlerOptions:{    
+                    hover: {delay: 200,pixelTolerance:2}
+                },
+                eventListeners:{
+                    scope:this,
+                    
+                    getfeatureinfo:function(evt){
+                        cleanup();
+                        // Issue #91
+                        var title = x.get("title") || x.get("name");
+                        if (infoFormat == "text/html") {
+                            var match = evt.text.match(/<body[^>]*>([\s\S]*)<\/body>/);
+                            if (match && !match[1].match(/^\s*$/)) {
+                                this.displayPopup(evt, title, match[1]);
+                            }
+                        } else if (infoFormat == "text/plain") {
+                            this.displayPopup(evt, title, '<pre>' + evt.text + '</pre>');
+                        } else if (evt.features && evt.features.length > 0) {
+                            this.displayPopup(evt, title, null, evt.features);
+                        } 
+                    },deactivate: cleanup
+                }
+            });
+            this.target.mapPanel.map.addControl(control);
+            this.activeControl=control;
+            control.activate();
+        }, this);
+        
+    },
+    
+    /** private: method[displayPopup]
+     * :arg evt: the event object from a 
+     *     :class:`OpenLayers.Control.GetFeatureInfo` control
+     * :arg title: a String to use for the title of the results section 
+     *     reporting the info to the user
+     * :arg text: ``String`` Body text.
+     * :arg features: ``Array`` With features.
+     * :arg onClose: ``Function`` Callback for popup close.
+     * :arg scope: ``Object`` Object scope for close function.
+     */
+    displayPopup: function(evt, title, text, features, onClose, scope) {
+        
+        var popup;
+        var popupKey = evt.xy.x + "." + evt.xy.y;
+                        
+        var item = this.useTabPanel ? {
+            title: title,     
+            layout: "accordion",
+            items: this.obtainFeatureInfoFromData(text, features, title),
+            autoScroll: true
+        } : {
+            title: title,           
+            layout: "accordion",  
+            items: this.obtainFeatureInfoFromData(text, features, title),
+            autoScroll: true,
+            autoWidth: true,
+            collapsible: true
+        };
+                        
+        if (!(popupKey in this.popupCache)) {
+            if(this.closePrevious) {
+                this.removeAllPopups();
+            }
+            var items = this.useTabPanel ? [{
+                xtype: 'tabpanel',
+                enableTabScroll:true,
+                activeTab: 0,
+                items: [item]
+            }] : [item];
+            
+            popup = this.addOutput({
+                xtype: "gx_popup",
+                title: this.popupTitle,
+                layout: this.useTabPanel ? "fit" : "accordion",
+                width: 490,
+                height: 320,
+                location: evt.xy,
+                map: this.target.mapPanel,
+                /*anchored: true,
+                unpinnable : true,*/
+                items: items,
+                draggable: true,
+                listeners: {
+                    close: (function(key) {
+                        return function(panel){
+                            if(onClose) {
+                                onClose.call(scope);
+                            }
+                            delete this.popupCache[key];
+                        };
+                    })(popupKey),
+                    scope: this
+                }
+            });
+            this.popupCache[popupKey] = popup;
+            // Issue #178: Save popup to hide when this tool is disabled;
+            this._lastPopup = popup;
+        } else {
+            popup = this.popupCache[popupKey];
+            
+            var container = this.useTabPanel ? popup.items.first() : popup;
+            container.add(item);
+        }
+                
+        popup.doLayout();
+    },
+    
+    /** private: method[clearPopups]
+     *  Clear last popup openned. Fixes issue #178.
+     */
+    clearPopups: function(){
+        if(this._lastPopup){
+            this._lastPopup.hide();
+        }
+    },
+    
+    /** private: method[obtainFeatureInfoFromData]
+     *  Obtain feature info panel by layer
+     * :arg text: ``String`` Body text.
+     * :arg features: ``Array`` With features.
+     * :arg parentTitle: ``String`` Title of parent tab.
+     */
+    obtainFeatureInfoFromData: function(text, features, parentTitle) {
+
+        var featureGrids = [];
+
+        if (features) {
+            var index = 0;
+            Ext.each(features,function(feature) {
+                featureGrids.push(this.obtainFeatureGrid(feature, String.format(this.defaultGroupTitleText, parentTitle, index++)));
+            }, this);
+        }else {
+            featureGrids.push(this.obtainFromText(text));
+        }
+
+        return featureGrids;
+    },
+    
+    /** private: method[obtainFeatureGrid]
+     *  Obtain feature grid
+     * :arg feature: ``Object`` Feature data.
+     * :arg title: ``String`` Title for the grid.
+     */
+    obtainFeatureGrid: function(feature, title){
+
+        var fields = [];
+
+        Ext.iterate(feature.data,function(fieldName,fieldValue) {
+            // We add the field.
+            fields.push(fieldName);
+        });
+
+        var featureGridConfig = {
+            xtype: 'gxp_editorgrid',
+            readOnly: true,
+            title: title,
+            fields: fields,
+            feature: feature,
+            layout: {
+                type: 'vbox',
+                align: 'stretch',
+                pack: 'start'
+            },
+            listeners: {
+                'beforeedit': function(e) {
+                    return false;
+                }
+            }
+        };
+
+        return featureGridConfig;
+    },
+    
+    /** private: method[obtainFromText]
+     *  Obtain a simple panel with text.
+     * :arg text: ``String`` Body text.
+     */
+    obtainFromText: function(text) {
+        return {
+            xtype: 'panel',
+            layout: 'fit',
+            items: {
+                xtype: 'label',
+                text: text ? text : this.noDataMsg
+            }
+        };
+    }
+
+});
+
+Ext.preg(MapStore.plugins.WMSGetFeatureInfoMenu.prototype.ptype, MapStore.plugins.WMSGetFeatureInfoMenu);

--- a/mapcomposer/buildjs.cfg
+++ b/mapcomposer/buildjs.cfg
@@ -216,6 +216,7 @@ include =
 	plugins/GeoLocationMenu.js
     locale/en.js
     locale/fr.js
+    plugins/FeatureEditorGrid.js
 
 [ux.js]
 root = app/static/script/ux
@@ -253,3 +254,10 @@ include =
     src/eventHandlers.js
     lib/ResourceBundle/Bundle.js
     lib/ResourceBundle/PropertyReader.js
+
+[mapstore.js]
+root = app/static/script/ux
+license = license.txt
+
+include =
+    MapStore/plugins/WMSGetFeatureInfoMenu.js


### PR DESCRIPTION
- Dependencies gxp/FeatureEditorGrid.js, gxp/FormFieldHelp.js and gxp/SchemaAnnotations.js has been added.
- Uses feature editor grid 'readonly' to show feature info in an accordeon. Fixes #91 issue.
- Closes feature info popup when the widget has been deactivated. Fixes #178 issue.

This widget has been added in ux/MapStore directory and build it in cfg file in a new asset called 'mapstore.js'.
