### PR TITLE
Legend options fieldset on PrintPreview

### DIFF
--- a/mapcomposer/app/static/externals/gxp/src/script/plugins/Print.js
+++ b/mapcomposer/app/static/externals/gxp/src/script/plugins/Print.js
@@ -96,6 +96,11 @@ gxp.plugins.Print = Ext.extend(gxp.plugins.Tool, {
      *  layout at that index will be selected as default in the print preview
      */
     defaultLayoutIndex:0,
+
+    /** api: config[appendLegendOptions]
+     *  Flag indicates that we need to change legend options for the print or not
+     **/
+    appendLegendOptions: false,
     
     
 
@@ -264,6 +269,8 @@ gxp.plugins.Print = Ext.extend(gxp.plugins.Tool, {
                             autoHeight: true,
                             mapTitle: this.target.about && this.target.about["title"],
                             comment: this.target.about && this.target.about["abstract"],
+                            // Add legend paramaters
+                            addFormParameters: this.appendLegendOptions,
                             listeners: {
                             	scope: this,
                             	"afterrender": function() {


### PR DESCRIPTION
When you set the print plugin flag 'appendLegendOptions' to true, you can manage these legend options in the PrintPreview:
- Icon size
- Font family
- Font size
- Dpi
- Force label
- Graticule

Playng with these options you can fix common issues as too big legend in the printed map or incorrect font family.
