### PR TITLE
Landscape option in the print plugin

### DIFF
--- a/mapcomposer/app/static/externals/PrintPreview/lib/GeoExt.ux/PrintPreview.js
+++ b/mapcomposer/app/static/externals/PrintPreview/lib/GeoExt.ux/PrintPreview.js
@@ -45,6 +45,8 @@ GeoExt.ux.PrintPreview = Ext.extend(Ext.Container, {
     legendTabText: "Legend",
     /** api: config[graticuleFieldLabelText] ``String`` i18n */
     graticuleFieldLabelText: 'Active graticule',
+    /** api: config[landscapeText] ``String`` i18n */
+    landscapeText: 'Landscape',
     /* end i18n */
     
     /** api: config[printProvider]
@@ -161,9 +163,19 @@ GeoExt.ux.PrintPreview = Ext.extend(Ext.Container, {
     addFormParameters: false,
 
     /** api: config[addGraticuleControl]
-     *  Flag indicates that we need to add graticule control to the legend options
+     *  Flag indicates that we need to add graticule control for the default tab
      **/
     addGraticuleControl: false,
+
+    /** api: config[addLandscapeControl]
+     *  Flag indicates that we need to add landscape control for the default tab
+     **/
+    addLandscapeControl: false,
+
+    /** api: config[landscape]
+     *  Print in landscape mode
+     **/
+    landscape: false,
     
     /** private: method[initComponent]
      */
@@ -333,6 +345,8 @@ GeoExt.ux.PrintPreview = Ext.extend(Ext.Container, {
             })
         };
         
+        var panelElements = [titleCfg];
+        
         if(this.legend) {
             var legendOnSeparatePageCheckbox = new Ext.form.Checkbox({
                 name: "legend",
@@ -342,6 +356,9 @@ GeoExt.ux.PrintPreview = Ext.extend(Ext.Container, {
                 ctCls: "gx-item-nowrap",
                 handler: function(cb, checked) {
                     this.legendOnSeparatePage = checked;
+                    if(this.addLandscapeControl){
+                        this.landscapeCheckbox.setDisabled(!checked);
+                    }
                     this.updateLayout();
                 },
                 cls : "gx-item-margin-left",                
@@ -375,20 +392,35 @@ GeoExt.ux.PrintPreview = Ext.extend(Ext.Container, {
                 },
                 cls : "gx-item-margin-left",
                 scope: this
-            });         
-        }
-        
-        var panelElements = [titleCfg];
+            });  
 
-        var checkItems = [
-                    legendCheckbox, 
-                    legendOnSeparatePageCheckbox,
-                    compactLegendCheckbox
-                ];
+            var checkItems = [
+                        legendCheckbox, 
+                        legendOnSeparatePageCheckbox,
+                        compactLegendCheckbox
+                    ];
+            
+            if(this.addLandscapeControl){
+                var landscapeCheckbox = new Ext.form.Checkbox({
+                    name: "landscape",
+                    checked: this.landscape,
+                    boxLabel: this.landscapeText,
+                    hideLabel: true,
+                    disabled: true,
+                    ctCls: "gx-item-nowrap",
+                    handler: function(cb, checked) {
+                        this.landscape = checked;
+                        this.updateLayout();
+                    },
+                    cls : "gx-item-margin-left",
+                    scope: this
+                });    
+                this.landscapeCheckbox = landscapeCheckbox;
+                checkItems.push(landscapeCheckbox);
+            }
 
-        this.addGraticuleControl && checkItems.push(this.getGraticuleCheckBox());
-        
-        if(this.legend){
+            this.addGraticuleControl && checkItems.push(this.getGraticuleCheckBox());  
+
             panelElements.push({
                 xtype: "container",
                 layout: "form",
@@ -483,7 +515,7 @@ GeoExt.ux.PrintPreview = Ext.extend(Ext.Container, {
             compactLegend: false,
             legendOnSeparatePage: false,
             
-        */      
+        */ 
         if(this.includeLegend){
             newLayoutName = currentLayout;
             
@@ -497,6 +529,14 @@ GeoExt.ux.PrintPreview = Ext.extend(Ext.Container, {
             
         } else {
             newLayoutName = currentLayout + '_no_legend';
+        }
+
+        /* Configure landscape layout: 
+         *   * _2_pages_compact_legend_landscape
+         *   * _2_pages_landscape
+        */
+        if(this.legendOnSeparatePage && this.landscape){
+            newLayoutName += "_landscape";
         }
         
         var nr = this.printProvider.fullLayouts.find("name", newLayoutName);

--- a/mapcomposer/app/static/externals/PrintPreview/resources/printing/advanced/config.yaml
+++ b/mapcomposer/app/static/externals/PrintPreview/resources/printing/advanced/config.yaml
@@ -393,7 +393,109 @@ layouts:
               classSpace: 4
               backgroundColor: #ffffff   
               reorderColumns: true    
-              dontBreakItems: true   
+              dontBreakItems: true  
+  #===========================================================================
+  A4_2_pages_legend_landscape :
+  #===========================================================================
+    mainPage:
+      rotation: true
+      pageSize: 842 595
+      landscape: false
+      items:
+        - !columns
+          absoluteX: 30
+          absoluteY: 575
+          width: 782
+          items:
+            - !image
+              maxWidth: 782
+              url: '/${configDir}/print_header.png'
+        - !map
+          width: 780
+          height: 400
+          absoluteX:30
+          absoluteY:475
+        - !columns
+          absoluteX: 750
+          absoluteY: 140
+          width: 40
+          items:
+            - !image
+              maxWidth: 40
+              maxHeight: 40
+              url: 'file:/${configDir}/Arrow_North_CFCF.svg'
+              rotation: '${rotation}'          
+        - !columns
+          absoluteX: 30
+          absoluteY: 55
+          width: 782
+          widths: [240, 300, 240]
+          items:
+            - !columns
+              nbColumns: 1
+              items:
+                - !text
+                  width: 300
+                  text: '${comment}'  
+                  fontEncoding: Cp1252
+                  fontSize: 9                     
+                  align: left
+                  vertAlign: middle               
+                - !text
+                  width: 300
+                  text: '${now MM.dd.yyyy}'  
+                  fontEncoding: Cp1252
+                  fontSize: 9                     
+                  align: left
+                  vertAlign: middle
+            - !text
+              align: center
+              vertAlign: middle
+              fontSize: 14
+              text: '${mapTitle}'
+            - !scalebar
+              align: right
+              vertAlign: middle
+              maxSize: 200
+              type: 'bar sub'
+              intervals: 5
+    lastPage:
+      rotation: true
+      pageSize: 842 595
+      landscape: false
+      items: 
+        #legend panel            
+        - !columns
+          config:
+            borderWidth: 0
+            cells:
+              - borderWidth: 0
+                borderWidthLeft: 0
+                borderColor: black
+                padding: 4
+                backgroundColor: white
+                vertAlign: bottom
+          absoluteX:30
+          absoluteY: 535
+          width: 780
+          widths: [780]
+          items:
+            - !legends      
+              failOnBrokenUrl: false
+              horizontalAlignment: left
+              iconMaxWidth: 0
+              iconMaxHeight: 0
+              maxHeight: 535
+              maxColumns: 5
+              maxWidth: 780
+              layerSpace: 5
+              layerFontSize: 12
+              classIndentation: 5
+              classFontSize: 8
+              classSpace: 4
+              backgroundColor: #ffffff   
+              reorderColumns: true    
+              dontBreakItems: true    
   #===========================================================================
   A4_2_pages_compact_legend :
   #===========================================================================
@@ -492,7 +594,107 @@ layouts:
               backgroundColor: #ffffff
               fitWidth: 200
               fitHeight: 390
-              failOnBrokenUrl: false             
+              failOnBrokenUrl: false 
+  #===========================================================================
+  A4_2_pages_compact_legend_landscape :
+  #===========================================================================
+    mainPage:
+      rotation: true
+      pageSize: 842 595
+      landscape: false
+      items:
+        - !columns
+          absoluteX: 30
+          absoluteY: 575
+          width: 782
+          items:
+            - !image
+              maxWidth: 782
+              url: '/${configDir}/print_header.png'
+        - !map
+          width: 780
+          height: 400
+          absoluteX:30
+          absoluteY:475
+        - !columns
+          absoluteX: 750
+          absoluteY: 140
+          width: 40
+          items:
+            - !image
+              maxWidth: 40
+              maxHeight: 40
+              url: 'file:/${configDir}/Arrow_North_CFCF.svg'
+              rotation: '${rotation}'          
+        - !columns
+          absoluteX: 30
+          absoluteY: 55
+          width: 782
+          widths: [240, 300, 240]
+          items:
+            - !columns
+              nbColumns: 1
+              items:
+                - !text
+                  width: 300
+                  text: '${comment}'  
+                  fontEncoding: Cp1252
+                  fontSize: 9                     
+                  align: left
+                  vertAlign: middle               
+                - !text
+                  width: 300
+                  text: '${now MM.dd.yyyy}'  
+                  fontEncoding: Cp1252
+                  fontSize: 9                     
+                  align: left
+                  vertAlign: middle
+            - !text
+              align: center
+              vertAlign: middle
+              fontSize: 14
+              text: '${mapTitle}'
+            - !scalebar
+              align: right
+              vertAlign: middle
+              maxSize: 200
+              type: 'bar sub'
+              intervals: 5
+    lastPage:
+      rotation: true
+      pageSize: 842 595
+      landscape: false
+      items: 
+        #legend panel            
+        - !columns
+          config:
+            borderWidth: 0
+            cells:
+              - borderWidth: 0
+                borderWidthLeft: 0
+                borderColor: black
+                padding: 4
+                backgroundColor: white
+                vertAlign: bottom
+          absoluteX:30
+          absoluteY: 535
+          width: 780
+          widths: [780]
+          items:
+            - !legends      
+              horizontalAlignment: left
+              #iconMaxWidth: 150
+              iconMaxHeight: 0
+              layerSpace: 5
+              layerFontSize: 12
+              classIndentation: 5
+              classFontSize: 8
+              classSpace: 4
+              backgroundColor: #ffffff
+              fitWidth: 200
+              fitHeight: 390
+              reorderColumns: true    
+              dontBreakItems: true    
   #===========================================================================
   A3 :
   #===========================================================================
@@ -845,6 +1047,108 @@ layouts:
               classSpace: 4
               backgroundColor: #ffffff 
               reorderColumns: true    
+              dontBreakItems: true    
+  #===========================================================================
+  A3_2_pages_legend_landscape :
+  #===========================================================================
+    mainPage:
+      rotation: true
+      pageSize: 842 595
+      landscape: false
+      items:
+        - !columns
+          absoluteX: 30
+          absoluteY: 575
+          width: 782
+          items:
+            - !image
+              maxWidth: 782
+              url: '/${configDir}/print_header.png'
+        - !map
+          width: 780
+          height: 400
+          absoluteX:30
+          absoluteY:475
+        - !columns
+          absoluteX: 750
+          absoluteY: 140
+          width: 40
+          items:
+            - !image
+              maxWidth: 40
+              maxHeight: 40
+              url: 'file:/${configDir}/Arrow_North_CFCF.svg'
+              rotation: '${rotation}'          
+        - !columns
+          absoluteX: 30
+          absoluteY: 55
+          width: 782
+          widths: [240, 300, 240]
+          items:
+            - !columns
+              nbColumns: 1
+              items:
+                - !text
+                  width: 300
+                  text: '${comment}'  
+                  fontEncoding: Cp1252
+                  fontSize: 9                     
+                  align: left
+                  vertAlign: middle               
+                - !text
+                  width: 300
+                  text: '${now MM.dd.yyyy}'  
+                  fontEncoding: Cp1252
+                  fontSize: 9                     
+                  align: left
+                  vertAlign: middle
+            - !text
+              align: center
+              vertAlign: middle
+              fontSize: 14
+              text: '${mapTitle}'
+            - !scalebar
+              align: right
+              vertAlign: middle
+              maxSize: 200
+              type: 'bar sub'
+              intervals: 5
+    lastPage:
+      rotation: true
+      pageSize: 842 595
+      landscape: false
+      items: 
+        #legend panel            
+        - !columns
+          config:
+            borderWidth: 0
+            cells:
+              - borderWidth: 0
+                borderWidthLeft: 0
+                borderColor: black
+                padding: 4
+                backgroundColor: white
+                vertAlign: bottom
+          absoluteX:30
+          absoluteY: 535
+          width: 780
+          widths: [780]
+          items:
+            - !legends      
+              failOnBrokenUrl: false
+              horizontalAlignment: left
+              iconMaxWidth: 0
+              iconMaxHeight: 0
+              maxHeight: 535
+              maxColumns: 5
+              maxWidth: 780
+              layerSpace: 5
+              layerFontSize: 12
+              classIndentation: 5
+              classFontSize: 8
+              classSpace: 4
+              backgroundColor: #ffffff   
+              reorderColumns: true    
               dontBreakItems: true       
   #===========================================================================
   A3_2_pages_compact_legend :
@@ -945,3 +1249,103 @@ layouts:
               fitWidth: 200
               fitHeight: 420
               failOnBrokenUrl: false
+  #===========================================================================
+  A3_2_pages_compact_legend_landscape :
+  #===========================================================================
+    mainPage:
+      rotation: true
+      pageSize: 842 595
+      landscape: false
+      items:
+        - !columns
+          absoluteX: 30
+          absoluteY: 575
+          width: 782
+          items:
+            - !image
+              maxWidth: 782
+              url: '/${configDir}/print_header.png'
+        - !map
+          width: 780
+          height: 400
+          absoluteX:30
+          absoluteY:475
+        - !columns
+          absoluteX: 750
+          absoluteY: 140
+          width: 40
+          items:
+            - !image
+              maxWidth: 40
+              maxHeight: 40
+              url: 'file:/${configDir}/Arrow_North_CFCF.svg'
+              rotation: '${rotation}'          
+        - !columns
+          absoluteX: 30
+          absoluteY: 55
+          width: 782
+          widths: [240, 300, 240]
+          items:
+            - !columns
+              nbColumns: 1
+              items:
+                - !text
+                  width: 300
+                  text: '${comment}'  
+                  fontEncoding: Cp1252
+                  fontSize: 9                     
+                  align: left
+                  vertAlign: middle               
+                - !text
+                  width: 300
+                  text: '${now MM.dd.yyyy}'  
+                  fontEncoding: Cp1252
+                  fontSize: 9                     
+                  align: left
+                  vertAlign: middle
+            - !text
+              align: center
+              vertAlign: middle
+              fontSize: 14
+              text: '${mapTitle}'
+            - !scalebar
+              align: right
+              vertAlign: middle
+              maxSize: 200
+              type: 'bar sub'
+              intervals: 5
+    lastPage:
+      rotation: true
+      pageSize: 842 595
+      landscape: false
+      items: 
+        #legend panel            
+        - !columns
+          config:
+            borderWidth: 0
+            cells:
+              - borderWidth: 0
+                borderWidthLeft: 0
+                borderColor: black
+                padding: 4
+                backgroundColor: white
+                vertAlign: bottom
+          absoluteX:30
+          absoluteY: 535
+          width: 780
+          widths: [780]
+          items:
+            - !legends      
+              horizontalAlignment: left
+              #iconMaxWidth: 150
+              iconMaxHeight: 0
+              layerSpace: 5
+              layerFontSize: 12
+              classIndentation: 5
+              classFontSize: 8
+              classSpace: 4
+              backgroundColor: #ffffff
+              fitWidth: 200
+              fitHeight: 390
+              reorderColumns: true    
+              dontBreakItems: true              

--- a/mapcomposer/app/static/externals/geoext-ext/data/PrintProvider.js
+++ b/mapcomposer/app/static/externals/geoext-ext/data/PrintProvider.js
@@ -553,7 +553,8 @@ GeoExt.data.PrintProvider = Ext.extend(Ext.util.Observable, {
         for(var i=0; i < layouts.length; i++){
             var layout = layouts[i];
             // > -1) && !(layout.name.indexOf("pages") > -1)
-            if(!(layout.name.indexOf("_legend") > 0)){
+            if(!(layout.name.indexOf("_legend") > 0) 
+                && !(layout.name.indexOf("_landscape") > 0)){
                 caps2.layouts.push(layout);
             }
         }

--- a/mapcomposer/app/static/externals/gxp/src/script/plugins/Print.js
+++ b/mapcomposer/app/static/externals/gxp/src/script/plugins/Print.js
@@ -106,6 +106,11 @@ gxp.plugins.Print = Ext.extend(gxp.plugins.Tool, {
      *  Flag indicates that we need to add graticule control to the default options
      **/
     addGraticuleControl: false,
+
+    /** api: config[addLandscapeControl]
+     *  Flag indicates that we need to add landscape control for the default tab
+     **/
+    addLandscapeControl: false,
     
     /** api: config[offsetByScale]
      *  ``Object`` Force to change the lat and lon offset for the graticule fixed to the scale 
@@ -376,6 +381,8 @@ gxp.plugins.Print = Ext.extend(gxp.plugins.Tool, {
                             addGraticuleControl: this.addGraticuleControl,
                             // Add graticule offset by scale
                             offsetByScale: this.offsetByScale,
+                            // Add landscape control
+                            addLandscapeControl: this.addLandscapeControl,
                             listeners: {
                                 scope: this,
                                 "afterrender": function() {


### PR DESCRIPTION
When you add the option 'addLandscapeControl' to the print plugin, a new checkbox apear when you select '2 pages legend' option. This option select the new configuration into the config.yaml as '*_landscape'.
