### PR TITLE
Print plugin fit to bounding box option

### DIFF
--- a/mapcomposer/app/static/config/queryConfig.js
+++ b/mapcomposer/app/static/config/queryConfig.js
@@ -217,6 +217,7 @@
 			"addGraticuleControl": false,
 			"legendOnSeparatePage": true,
 			"addLandscapeControl": true,
+    		"bboxFit": true,
 			"actionTarget":{
 			    "target": "paneltbar",
 				"index":4

--- a/mapcomposer/app/static/externals/geoext-ext/data/PrintPage.js
+++ b/mapcomposer/app/static/externals/geoext-ext/data/PrintPage.js
@@ -51,6 +51,11 @@ GeoExt.data.PrintPage = Ext.extend(Ext.util.Observable, {
      */
     scale: null,
     
+    /** api: property[bbox]
+     *  ``OpenLayers.BoundingBox`` The current bbox of the map.
+     */
+    bbox: null,
+    
     /** api: property[rotation]
      *  ``Float`` The current rotation of the page. Read-only.
      */
@@ -243,6 +248,25 @@ GeoExt.data.PrintPage = Ext.extend(Ext.util.Observable, {
             center: center,
             scale: scale
         });
+    },
+    
+    /** api: method[fitToBBox]
+     *  :param bbox: :class:``OpenLayers.BoundingBox``
+     *      The bounding box to fit the page to.
+     *
+     *  Fits the page layout to a bounding box.
+     * 
+     *  If you fit to a bounding box, scale and center turn null and 
+     *  only use bbox to fit the map
+     * 
+     */
+    fitToBBox: function(bbox) {
+        this._updating = true;
+        this.center = null;
+        this.scale = null;
+        this.bbox = bbox;
+        this.fireEvent("change", this, {bbox: bbox});
+        this._updating = false;
     },
 
     /** private: method[updateFeature]

--- a/mapcomposer/app/static/externals/geoext-ext/data/PrintProvider.js
+++ b/mapcomposer/app/static/externals/geoext-ext/data/PrintProvider.js
@@ -431,11 +431,20 @@ GeoExt.data.PrintProvider = Ext.extend(Ext.util.Observable, {
         
         var encodedPages = [];
         Ext.each(pages, function(page) {
-            encodedPages.push(Ext.apply({
-                center: [page.center.lon, page.center.lat],
-                scale: page.scale.get("value"),
-                rotation: page.rotation
-            }, page.customParams));
+            if(page.bbox){
+                // only bbox fix!!
+                encodedPages.push(Ext.apply({
+                    bbox: page.bbox.toArray(),
+                    rotation: page.rotation
+                }, page.customParams));
+            }else{
+                // default: use center and scale!!
+                encodedPages.push(Ext.apply({
+                    center: [page.center.lon, page.center.lat],
+                    scale: page.scale.get("value"),
+                    rotation: page.rotation
+                }, page.customParams));
+            }
         }, this);
         jsonData.pages = encodedPages;
         

--- a/mapcomposer/app/static/externals/gxp/src/script/plugins/Print.js
+++ b/mapcomposer/app/static/externals/gxp/src/script/plugins/Print.js
@@ -111,104 +111,11 @@ gxp.plugins.Print = Ext.extend(gxp.plugins.Tool, {
      *  Flag indicates that we need to add landscape control for the default tab
      **/
     addLandscapeControl: false,
-    
-    /** api: config[offsetByScale]
-     *  ``Object`` Force to change the lat and lon offset for the graticule fixed to the scale 
-     */
-    offsetByScale:{
-        20000000:{
-            lonOffsetX: 0,
-            lonOffsetY: 180,
-            latOffsetX: -270,
-            latOffsetY: 2
-        },
-        10000000:{
-            lonOffsetX: 0,
-            lonOffsetY: 180,
-            latOffsetX: -270,
-            latOffsetY: 2
-        },
-        4000000:{
-            lonOffsetX: 0,
-            lonOffsetY: 50,
-            latOffsetX: -50,
-            latOffsetY: 2
-        },
-        2000000:{
-            lonOffsetX: 0,
-            lonOffsetY: 50,
-            latOffsetX: -50,
-            latOffsetY: 2
-        },
-        1000000:{
-            lonOffsetX: 0,
-            lonOffsetY: 50,
-            latOffsetX: -50,
-            latOffsetY: 2
-        },
-        500000:{
-            lonOffsetX: 0,
-            lonOffsetY: 50,
-            latOffsetX: -50,
-            latOffsetY: 2
-        },
-        200000:{
-            lonOffsetX: 0,
-            lonOffsetY: 100,
-            latOffsetX: -150,
-            latOffsetY: 2
-        },
-        100000:{
-            lonOffsetX: 0,
-            lonOffsetY: 100,
-            latOffsetX: -150,
-            latOffsetY: 2
-        },
-        50000:{
-            lonOffsetX: 0,
-            lonOffsetY: 100,
-            latOffsetX: -150,
-            latOffsetY: 2
-        },
-        20000:{
-            lonOffsetX: 0,
-            lonOffsetY: 200,
-            latOffsetX: -245,
-            latOffsetY: 2
-        },
-        10000:{
-            lonOffsetX: 0,
-            lonOffsetY: 200,
-            latOffsetX: -245,
-            latOffsetY: 2
-        },
-        5000:{
-            lonOffsetX: 0,
-            lonOffsetY: 200,
-            latOffsetX: -245,
-            latOffsetY: 2
-        },
-        2000:{
-            lonOffsetX: 0,
-            lonOffsetY: 45,
-            latOffsetX: -45,
-            latOffsetY: 2
-        },
-        1000:{
-            lonOffsetX: 0,
-            lonOffsetY: 45,
-            latOffsetX: -45,
-            latOffsetY: 2
-        },
-        500:{
-            lonOffsetX: 0,
-            lonOffsetY: 45,
-            latOffsetX: -45,
-            latOffsetY: 2
-        }
-    },
-    
-    
+
+    /** api: config[bboxFit]
+     *  Flag indicates that the mapPanel is fixed by bbox (not by scale)
+     **/
+    bboxFit: false,
 
     /** private: method[constructor]
      */
@@ -379,10 +286,10 @@ gxp.plugins.Print = Ext.extend(gxp.plugins.Tool, {
                             addFormParameters: this.appendLegendOptions,
                             // Add graticule option
                             addGraticuleControl: this.addGraticuleControl,
-                            // Add graticule offset by scale
-                            offsetByScale: this.offsetByScale,
                             // Add landscape control
                             addLandscapeControl: this.addLandscapeControl,
+                            // BBox fit
+                            bboxFit: this.bboxFit,
                             listeners: {
                                 scope: this,
                                 "afterrender": function() {
@@ -410,12 +317,15 @@ gxp.plugins.Print = Ext.extend(gxp.plugins.Tool, {
                                 }
                             },
                             printMapPanel: {
+                                // BBox fit
+                                bboxFit: this.bboxFit,
                                 map: Ext.applyIf({
                                     controls: [
                                         //UNCOMMENT TO ADD CONTROLS TO PRINT PREVIEW
-                                        //new OpenLayers.Control.Navigation(),
-                                        //new OpenLayers.Control.PanPanel(),
-                                        //new OpenLayers.Control.ZoomPanel(),
+                                        // CAUTION: For bboxFit option = true you can't active it
+                                        // new OpenLayers.Control.Navigation(),
+                                        // new OpenLayers.Control.PanPanel(),
+                                        // new OpenLayers.Control.ZoomPanel(),
                                         new OpenLayers.Control.Attribution()
                                     ],
                                     eventListeners: {


### PR DESCRIPTION
When you activate this option, the print preview is fixed to the actual bounding box and hides the scale.

This commit adds neccesary changes to:
- PrintProvider.js
- PrintPage.js
- PrintMapPanel.js
- PrintPreview.js
- Print.js

Yo can activate this option in Print plugin with  `"bboxFit": true` in mapStoreConfig.js.

This pull request fixes #241
