### PR TITLE
Service Box widgets improvements.

### DIFF
--- a/mapcomposer/app/static/externals/gxp/src/script/plugins/PrintSnapshot.js
+++ b/mapcomposer/app/static/externals/gxp/src/script/plugins/PrintSnapshot.js
@@ -139,17 +139,18 @@ gxp.plugins.PrintSnapshot = Ext.extend(gxp.plugins.Tool, {
                 			}
                 		}
                 	}
-                	
-                	var gsURL = baseURL + 
-                	    "LAYERS=" + supportedLayers.join(",") +
-                		"&FORMAT=" + encodeURIComponent("image/png") + 
-						"&SRS=" + srsID +  
-						"&VERSION=1.1.1" +
-						"&REQUEST=GetMap" +
-						"&BBOX=" + encodeURIComponent(extent.toBBOX())+
-						"&WIDTH=" + width +
-						"&HEIGHT=" + height +
-						"&CQL_FILTER=" + filters.join(";");
+                    
+                    var gsURL = baseURL + 
+                        "SERVICE=WMS" +
+                        "&LAYERS=" + supportedLayers.join(",") +
+                        "&FORMAT=" + encodeURIComponent("image/png") + 
+                        "&SRS=" + srsID +  
+                        "&VERSION=1.1.1" +
+                        "&REQUEST=GetMap" +
+                        "&BBOX=" + encodeURIComponent(extent.toBBOX())+
+                        "&WIDTH=" + width +
+                        "&HEIGHT=" + height +
+                        "&CQL_FILTER=" + filters.join(";");
 						
                 	var mHost = me.service.split("/");
 					
@@ -209,14 +210,23 @@ gxp.plugins.PrintSnapshot = Ext.extend(gxp.plugins.Tool, {
 						    scope: this,
 						    success: function(response, opts){
 								if (response.readyState == 4 && response.status == 200){
-									var fname = "mapstore-snapshot.png";
-									
-									var mUrl = me.service + "UploadCanvas";
-										mUrl = mHost[2] == location.host ? mUrl + "?ID=" + response.responseText + "&fn=" + fname : proxy + encodeURIComponent(mUrl + "?ID=" + response.responseText + "&fn=" + fname);
-									
-									window.location.assign(mUrl);
-									enableSaving = true;
-									
+								    if(response.responseText && response.responseText.indexOf("\"success\":false") < 0){
+								        var fname = "mapstore-snapshot.png";
+								    
+								        var mUrl = me.service + "UploadCanvas";
+								            mUrl = mHost[2] == location.host ? mUrl + "?ID=" + response.responseText + "&fn=" + fname : proxy + encodeURIComponent(mUrl + "?ID=" + response.responseText + "&fn=" + fname);
+								        
+								        window.location.assign(mUrl);
+								        enableSaving = true;
+								    }else{
+								        // this error should go to failure
+								        Ext.Msg.show({
+								             title: me.printStapshotTitle,
+								             msg: me.generatingErrorMsg + " " + gxp.util.getResponseFailureServiceBoxMessage(response),
+								             width: 300,
+								             icon: Ext.MessageBox.ERROR
+								        });
+								    }
 								}else if (response.status != 200){
 									Ext.Msg.show({
 										 title: 'Print Snapshot',
@@ -228,8 +238,8 @@ gxp.plugins.PrintSnapshot = Ext.extend(gxp.plugins.Tool, {
 						    },
 						    failure:  function(response, opts){
 								Ext.Msg.show({
-									 title: this.printStapshotTitle,
-									 msg: this.generatingErrorMsg + " " + e,
+									 title: me.printStapshotTitle,
+									 msg: me.generatingErrorMsg + " " + gxp.util.getResponseFailureServiceBoxMessage(response),
 									 width: 300,
 									 icon: Ext.MessageBox.ERROR
 								});

--- a/mapcomposer/app/static/externals/gxp/src/script/util.js
+++ b/mapcomposer/app/static/externals/gxp/src/script/util.js
@@ -350,6 +350,38 @@ gxp.util = {
         return function(data) {
             return MD5_hexhash(data);
         };
-    })()
+    })(),
+
+    /** api: function[getResponseFailureMessage]
+     *  :arg response: ``Object`` Response received
+     *  :return: ``String`` A single string representing the error.
+     *
+     *  Get a string message from a service box action fail.
+     */ 
+    getResponseFailureServiceBoxMessage: function (response){
+        // obtain responseText
+        var errorMessage = response ? response.responseText: null;
+        if(response && response.responseText){
+            try{
+                var errorObject = JSON.parse(errorMessage);
+                /*
+                 * The format of the error object is:
+                 * {
+                 *      "errorMessage":"message",
+                 *      "details":{`details map`},
+                 *      "errorCode":`code of the error`,
+                 *      "success":false
+                 * }
+                 * 
+                 * @see Utilities#JSON_MODEL on ServiceBox
+                 */
+                // TODO: here we can use the the errorCode to obtain localized messages
+                errorMessage = errorObject.errorMessage;
+            }catch(e) {
+                // use responseText   
+            }
+        }
+        return errorMessage;
+    }
 
 };

--- a/mapcomposer/app/static/externals/gxp/src/script/widgets/KMLFileUploadPanel.js
+++ b/mapcomposer/app/static/externals/gxp/src/script/widgets/KMLFileUploadPanel.js
@@ -142,10 +142,9 @@ gxp.KMLFileUploadPanel = Ext.extend(Ext.FormPanel, {
                         //reset: true,
                         scope: this,
                         failure: function(form, action){
-                            
                             Ext.Msg.show({
                                 title: this.failedUploadingTitle,
-                                msg: action.responseText,
+                                msg: gxp.util.getResponseFailureServiceBoxMessage(action.response),
                                 buttons: Ext.Msg.OK,
                                 icon: Ext.MessageBox.ERROR
                             });

--- a/mapcomposer/app/static/externals/gxp/src/script/widgets/MapFileDownloadPanel.js
+++ b/mapcomposer/app/static/externals/gxp/src/script/widgets/MapFileDownloadPanel.js
@@ -179,6 +179,7 @@ gxp.MapFileDownloadPanel = Ext.extend(Ext.FormPanel, {
                     this.appMask.hide();
                     this.fireEvent("downloadcomplete", this, null);
                 }else{
+                    this.appMask.hide();
                     Ext.Msg.show({
                         title: this.failedUploadingTitle,
                         msg: request.statusText,

--- a/mapcomposer/app/static/externals/gxp/src/script/widgets/MapFileUploadPanel.js
+++ b/mapcomposer/app/static/externals/gxp/src/script/widgets/MapFileUploadPanel.js
@@ -124,10 +124,9 @@ gxp.MapFileUploadPanel = Ext.extend(Ext.FormPanel, {
                         waitMsgTarget: true,
                         scope: this,
                         failure: function(form, action){
-                            
                             Ext.Msg.show({
                                 title: this.failedUploadingTitle,
-                                msg: action.responseText,
+                                msg: gxp.util.getResponseFailureServiceBoxMessage(action.response),
                                 buttons: Ext.Msg.OK,
                                 icon: Ext.MessageBox.ERROR
                             });


### PR DESCRIPTION
Changes on widgets:
- PrintSnapshot
- KMLFileUploadPanel
- MapFileUploadPanel

in order to include the error log from servicebox.

Also include:
- PrintSnapshot --> Add SERVICE=WMS to the request URL.
- MapFileDownloadPanel --> Hide load mask when the request fails.

This changes and the geosolutions-it/servicebox#5 pull request fixes #138 issue.
