### PR TITLE
Graticule dimensions fixes.

### DIFF
--- a/mapcomposer/app/static/externals/PrintPreview/lib/GeoExt.ux/PrintPreview.js
+++ b/mapcomposer/app/static/externals/PrintPreview/lib/GeoExt.ux/PrintPreview.js
@@ -182,6 +182,11 @@ GeoExt.ux.PrintPreview = Ext.extend(Ext.Container, {
      **/
     bboxFit: false,
 
+    /** api: config[bboxFit]
+     *  Flag indicates that the printed map is fixed by bbox to the current preview (allow use scale, but really uses the preview extend)
+     **/
+    bboxPreviewFit: false,
+
     /** api: config[graticuleOptions]
      *  `Object` map with default parameters for the `OpenLayer.Control.Graticule` control when this.addGraticuleControl is enabled
      **/
@@ -194,6 +199,7 @@ GeoExt.ux.PrintPreview = Ext.extend(Ext.Container, {
             sourceMap: this.sourceMap,
             printProvider: this.printProvider,
             bboxFit: this.bboxFit,
+            bboxPreviewFit: this.bboxPreviewFit,
             width : 400
         };
         if(this.printMapPanel) {

--- a/mapcomposer/app/static/externals/geoext-ext/data/PrintProvider.js
+++ b/mapcomposer/app/static/externals/geoext-ext/data/PrintProvider.js
@@ -172,6 +172,11 @@ GeoExt.data.PrintProvider = Ext.extend(Ext.util.Observable, {
      */
     layout: null,
 
+    /** api: config[fitToBbox]
+     *  ``Boolean`` Flag to fit the print preview to the exact extent of the print preview map. 
+     */
+    fitToBbox: false,
+
     /** private:  method[constructor]
      *  Private constructor override.
      */
@@ -437,7 +442,13 @@ GeoExt.data.PrintProvider = Ext.extend(Ext.util.Observable, {
                     bbox: page.bbox.toArray(),
                     rotation: page.rotation
                 }, page.customParams));
-            }else{
+            }else if(this.fitToBbox){
+                // fit to bbox of print preview
+                encodedPages.push(Ext.apply({
+                    bbox: map.getExtent().toArray(),
+                    rotation: page.rotation
+                }, page.customParams));
+            }else {
                 // default: use center and scale!!
                 encodedPages.push(Ext.apply({
                     center: [page.center.lon, page.center.lat],

--- a/mapcomposer/app/static/externals/geoext-ext/widgets/PrintMapPanel.js
+++ b/mapcomposer/app/static/externals/geoext-ext/widgets/PrintMapPanel.js
@@ -164,6 +164,11 @@ GeoExt.PrintMapPanel = Ext.extend(GeoExt.MapPanel, {
      *  Flag indicates that the mapPanel is fixed by bbox (not by scale)
      **/
     bboxFit: false,
+
+    /** api: config[bboxFit]
+     *  Flag indicates that the printed map is fixed by bbox to the current preview (allow use scale, but really uses the preview extend)
+     **/
+    bboxPreviewFit: false,
     
     /**
      * private: method[initComponent]
@@ -200,6 +205,11 @@ GeoExt.PrintMapPanel = Ext.extend(GeoExt.MapPanel, {
                 });
             }
         }
+
+        // Apply fitToBbox
+        Ext.apply(this.printProvider,{
+            fitToBbox: this.bboxPreviewFit
+        });
 
         Ext.applyIf(this.map, {
             projection: this.sourceMap.getProjection(),

--- a/mapcomposer/app/static/externals/gxp/src/script/plugins/Print.js
+++ b/mapcomposer/app/static/externals/gxp/src/script/plugins/Print.js
@@ -118,6 +118,11 @@ gxp.plugins.Print = Ext.extend(gxp.plugins.Tool, {
      **/
     bboxFit: false,
 
+    /** api: config[bboxFit]
+     *  Flag indicates that the printed map is fixed by bbox to the current preview (allow use scale, but really uses the preview extend)
+     **/
+    bboxPreviewFit: false,
+
     /** api: config[graticuleOptions]
      *  `Object` map with default parameters for the `OpenLayer.Control.Graticule` control when this.addGraticuleControl is enabled
      **/
@@ -133,9 +138,9 @@ gxp.plugins.Print = Ext.extend(gxp.plugins.Tool, {
      */
     addActions: function() {
 
-        // force bboxFit if graticule control it's enabled
-        if(this.addGraticuleControl){
-            this.bboxFit = true;
+        // force bboxPreviewFit if graticule control it's enabled and bboxFit is not enabled
+        if(this.addGraticuleControl && !this.bboxFit){
+            this.bboxPreviewFit = true;
         }
 
         // don't add any action if there is no print service configured
@@ -311,6 +316,8 @@ gxp.plugins.Print = Ext.extend(gxp.plugins.Tool, {
                             addLandscapeControl: this.addLandscapeControl,
                             // BBox fit
                             bboxFit: this.bboxFit,
+                            // BBox preview fit
+                            bboxPreviewFit: this.bboxPreviewFit,
                             // Graticule options
                             graticuleOptions: this.graticuleOptions,
                             listeners: {


### PR DESCRIPTION
- New configuration on print plugin `bboxPreviewFit` to fit to the print preview
- Use it by default when the graticule control is enabled and the `bboxFit` isn't.

This commit fixes #319 issue.
