### PR TITLE
Proposal #5: Geocoder based on WFS spatial selectors

### DIFF
--- a/mapcomposer/app/static/externals/gxp/src/script/plugins/spatialselector/Geocoder.js
+++ b/mapcomposer/app/static/externals/gxp/src/script/plugins/spatialselector/Geocoder.js
@@ -1,0 +1,283 @@
+/**
+ *  Copyright (C) 2007 - 2014 GeoSolutions S.A.S.
+ *  http://www.geo-solutions.it
+ *
+ *  GPLv3 + Classpath exception
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * @requires plugins/spatialselector/SpatialSelectorMethod.js
+ */
+ 
+/**
+ * @author Alejandro Diaz
+ */
+
+/** api: (define)
+ *  module = gxp.plugins.spatialselector
+ *  class = Geocoder
+ */
+
+/** api: (extends)
+ *  plugins/Tool.js
+ */
+Ext.namespace('gxp.plugins.spatialselector');
+
+/** api: constructor
+ *  .. class:: Geocoder(config)
+ *
+ *    Geocoder based on spatial selectors
+ */
+gxp.plugins.spatialselector.Geocoder = Ext.extend(gxp.plugins.Tool, {
+
+	/* ptype = gxp_spatial_selector_geocoder */
+	ptype : 'gxp_spatial_selector_geocoder',
+
+	/** api: config[layoutConfig]
+	 *  ``Object``
+	 *  Configuration for the output layout.
+	 */
+
+	/** api: config[crossParameters]
+	 *  ``Object``
+	 *  Configuration for crossParameters by selectors. When you select a result for the first combo, 
+	 *  it will enable the second or more comboboxes and copy the parameter configured in the second one
+	 */
+    crossParameters:{},
+
+    /** api: config[searchBtnCls]
+     * ``String``
+     * Icon cls for the search button.
+     */
+	searchBtnCls: "gxp-icon-find",
+
+    /** api: config[resetBtnCls]
+     * ``String``
+     * Icon cls for the search button.
+     */
+	resetBtnCls: "cancel",
+
+	/** i18n **/
+	/** api: config[titleText]
+	 * ``String``
+	 * Title for the output (i18n).
+	 */
+	titleText: "Geocoder",
+
+	/** api: config[searchText]
+	 * ``String``
+	 * Search text (i18n).
+	 */
+	searchText: "Search",
+
+	/** api: config[searchTpText]
+	 * ``String``
+	 * Search tooltip text (i18n).
+	 */
+	searchTpText: "Search selected location and zoom in on map",
+
+	/** api: config[resetText]
+	 * ``String``
+	 * Reset text (i18n).
+	 */
+	resetText: "Reset",
+
+	/** api: config[resetText]
+	 * ``String``
+	 * Reset text (i18n).
+	 */
+	resetTpText: "Reset location search",
+
+	/** api: config[translatedKeys]
+	 * ``String``
+	 * Translated keys for spatial selectors (i18n).
+	 */
+	translatedKeys: {
+		"name": "Street",
+		"number": "Number"
+	},
+	/** EoF i18n **/
+
+	/** api: method[constructor]
+	 * Init spatialSelectors .
+	 */
+	constructor : function(config) {
+		// default layout configuration
+		this.layoutConfig = {
+    		xtype: "panel",
+    		layout: "form",
+    		defaults:{
+    			layout:"fieldfet"
+    		}
+		};
+
+		// Apply config
+		Ext.apply(this, config);
+		
+		return gxp.plugins.spatialselector.SpatialSelector.superclass.constructor.call(this, arguments);
+	},
+
+    /** api: method[addOutput]
+     */
+    addOutput: function() {
+
+		// initialize spatial selectors
+		this.spatialSelectors = {};
+		this.spatialSelectorsItems = [];
+		if(this.spatialSelectorsConfig){
+			for (var key in this.spatialSelectorsConfig){
+				var spConfig = this.spatialSelectorsConfig[key];
+				spConfig.target = this.target;
+				// Add i18n support by spatial selector 
+				if(this.translatedKeys[key]){
+					spConfig["name"] = this.translatedKeys[key];
+				}
+				if(spConfig.id 
+					&& this.target 
+					&& this.target.tools
+					&& this.target.tools[spConfig.id]){
+					this.spatialSelectors[key] = this.target.tools[spConfig.id];
+				}else{
+					var plugin = Ext.ComponentMgr.createPlugin(spConfig);
+					if(this.target 
+						&& this.target.tools){
+						this.target.tools[spConfig.id] = plugin;
+					}
+					this.spatialSelectors[key] = plugin;
+					var selectorItem = plugin.getSelectionMethodItem();
+					selectorItem.value = key;
+					this.spatialSelectorsItems.push(selectorItem);
+				}
+			}	
+		}
+
+    	// prepare layout
+    	var layout = {};
+		Ext.apply(layout, this.layoutConfig);
+		if(!layout.title){
+			layout.title = this.titleText;
+		}
+
+	    // initialize layout
+		layout.items = [];
+    	if(this.spatialSelectors){
+	    	for (var key in this.spatialSelectors){
+	    		var output = this.spatialSelectors[key].addOutput();
+	    		output.on("geometrySelect", this.onGeometrySelect, {scope:this, type: key});
+	    		if(output){
+	    			if(!this.crossParameters[key]){
+	    				output.setDisabled(true);
+	    			}
+					layout.items.push(output);
+	    		}
+	    	}
+	    }
+
+	    layout.buttonAlign = "right";
+
+	    layout.bbar = [
+	    "->", 
+	    {
+            xtype   : "button",
+            text : this.searchText,
+            tooltip : this.searchTpText,
+            iconCls: this.searchBtnCls,
+			scope   : this,
+			handler : this.search
+		},{
+            xtype   : "button",
+            text : this.resetText,
+            tooltip : this.resetTpText,
+            iconCls: this.resetBtnCls,
+			scope   : this,
+			handler : this.reset
+		}];
+
+	    var output = gxp.plugins.spatialselector.Geocoder.superclass.addOutput.call(this, layout);
+
+    	return output;
+    },
+
+    onGeometrySelect:function(geometry){
+    	var params = this;
+    	var me = params.scope;
+    	var type = params.type;
+    	var selected = me.spatialSelectors[type].wfsComboBox.getValue();
+    	var store = me.spatialSelectors[type].wfsComboBox.store;
+		var records = store.getRange();
+		var size = store.getCount();
+		var recordData = null;
+    	for(var i = 0; i < size; i++){
+			var record = records[i];
+			if (record && record.data.name == selected) {
+				recordData = record;
+				break;
+    		}
+    	}
+    	var selectedProperties = recordData.json.properties;
+    	if(me.crossParameters[type]){
+    		for(var parameter in me.crossParameters[type]){
+    			var value = selectedProperties[parameter];
+    			for(var targetCombo in me.crossParameters[type][parameter]){
+    				// enable combo
+    				me.spatialSelectors[targetCombo].output.setDisabled(false);
+    				var comboBox = me.spatialSelectors[targetCombo].wfsComboBox;
+    				// Apply filter (only one at time)
+		    		if(!comboBox.vendorParams){
+		    			comboBox.vendorParams = {};
+		    		}
+		    		var cql_filter = me.crossParameters[type][parameter][targetCombo] + " = " + value;
+		    		Ext.apply(comboBox.vendorParams,{
+		    			cql_filter: cql_filter
+		    		});
+    			}
+    		}
+    	}
+    	me.geometry = geometry;
+    },
+
+	/** api: method[reset]
+	 * Search action.
+	 */
+    search: function(){
+
+    	var geometry = this.geometry;
+
+		if (geometry && geometry.getBounds) {
+			var dataExtent = geometry.getBounds();
+			this.target.mapPanel.map.zoomToExtent(dataExtent, closest=false);
+		}
+    },
+
+	/** api: method[reset]
+	 * Reset the state of the Geocoder.
+	 */
+    reset: function(){
+    	this.geometry = null;
+    	if(this.spatialSelectors){
+	    	for (var key in this.spatialSelectors){
+	    		this.spatialSelectors[key].wfsComboBox.reset();
+	    		this.spatialSelectors[key].reset();
+    			if(!this.crossParameters[key]){
+    				this.spatialSelectors[key].output.setDisabled(true);
+    			}
+	    	}
+    	}
+    }
+
+});
+
+Ext.preg(gxp.plugins.spatialselector.Geocoder.prototype.ptype, gxp.plugins.spatialselector.Geocoder);

--- a/mapcomposer/app/static/externals/gxp/src/script/plugins/spatialselector/SpatialSelectorMethod.js
+++ b/mapcomposer/app/static/externals/gxp/src/script/plugins/spatialselector/SpatialSelectorMethod.js
@@ -133,6 +133,12 @@ gxp.plugins.spatialselector.SpatialSelectorMethod = Ext.extend(gxp.plugins.Tool,
 	 */
 	areaLabel : "Area",
 
+	/** api: config[lengthLabel]
+	 * ``String``
+	 * Text for the Selection Summary Perimeter Label (i18n).
+	 */
+	lengthLabel : "Length",
+
 	/** api: config[perimeterLabel]
 	 * ``String``
 	 * Text for the Selection Summary Perimeter Label (i18n).
@@ -261,6 +267,7 @@ gxp.plugins.spatialselector.SpatialSelectorMethod = Ext.extend(gxp.plugins.Tool,
 			}
 
 			this.addFeatureSummary(geometry);
+			this.output.fireEvent("geometrySelect", geometry);
 		} 
     },
 
@@ -316,8 +323,13 @@ gxp.plugins.spatialselector.SpatialSelectorMethod = Ext.extend(gxp.plugins.Tool,
 		var summary = "", metricUnit = "km";
 
 		var area = this.getArea(geometry, metricUnit);
+		var length = this.getLength(geometry, metricUnit);
 		if (area) {
 			summary += this.areaLabel + ": " + area + " " + metricUnit + '<sup>2</sup>' + '<br />';
+		}else if (length) {
+			summary += this.lengthLabel + ": " + length + " " + metricUnit + '<br />';
+		}else if(geometry instanceof OpenLayers.Geometry.Point){
+			summary += "X: " + geometry.x + ", Y:" + geometry.y + '<sup>2</sup>' + '<br />';
 		}
 
 		return summary;
@@ -335,13 +347,16 @@ gxp.plugins.spatialselector.SpatialSelectorMethod = Ext.extend(gxp.plugins.Tool,
 	 */
 	getArea : function(geometry, units) {
 		var area, geomUnits;
-		area = geometry.getGeodesicArea(this.target.mapPanel.map.getProjectionObject());
-		geomUnits = "m";
+		area = geometry.getArea();
+		if(area > 0){
+			area = geometry.getGeodesicArea(this.target.mapPanel.map.getProjectionObject());
+			geomUnits = "m";
 
-		var inPerDisplayUnit = OpenLayers.INCHES_PER_UNIT[units];
-		if (inPerDisplayUnit) {
-			var inPerMapUnit = OpenLayers.INCHES_PER_UNIT[geomUnits];
-			area *= Math.pow((inPerMapUnit / inPerDisplayUnit), 2);
+			var inPerDisplayUnit = OpenLayers.INCHES_PER_UNIT[units];
+			if (inPerDisplayUnit) {
+				var inPerMapUnit = OpenLayers.INCHES_PER_UNIT[geomUnits];
+				area *= Math.pow((inPerMapUnit / inPerDisplayUnit), 2);
+			}
 		}
 		return area;
 	},
@@ -358,13 +373,16 @@ gxp.plugins.spatialselector.SpatialSelectorMethod = Ext.extend(gxp.plugins.Tool,
 	 */
 	getLength : function(geometry, units) {
 		var length, geomUnits;
-		length = geometry.getGeodesicLength(this.target.mapPanel.map.getProjectionObject());
-		geomUnits = "m";
+		length = geometry.getLength();
+		if(length){
+			length = geometry.getGeodesicLength(this.target.mapPanel.map.getProjectionObject());
+			geomUnits = "m";
 
-		var inPerDisplayUnit = OpenLayers.INCHES_PER_UNIT[units];
-		if (inPerDisplayUnit) {
-			var inPerMapUnit = OpenLayers.INCHES_PER_UNIT[geomUnits];
-			length *= (inPerMapUnit / inPerDisplayUnit);
+			var inPerDisplayUnit = OpenLayers.INCHES_PER_UNIT[units];
+			if (inPerDisplayUnit) {
+				var inPerMapUnit = OpenLayers.INCHES_PER_UNIT[geomUnits];
+				length *= (inPerMapUnit / inPerDisplayUnit);
+			}
 		}
 		return length;
 	}

--- a/mapcomposer/app/static/translations/en.js
+++ b/mapcomposer/app/static/translations/en.js
@@ -667,6 +667,7 @@ GeoExt.Lang.add("en", {
     "gxp.plugins.spatialselector.SpatialSelectorMethod.prototype" :{
         areaLabel : "Area",
         perimeterLabel : "Perimeter",
+        lengthLabel: "Length",
         radiusLabel : "Radius",
         centroidLabel : "Centroid",
         selectionSummary: "Selection Summary"
@@ -721,5 +722,17 @@ GeoExt.Lang.add("en", {
     "gxp.plugins.spatialselector.PolygonSpatialSelectorMethod.prototype" :{
         name  : 'Polygon',
         label : 'Polygon'
+    },
+    
+    "gxp.plugins.spatialselector.Geocoder.prototype" :{
+        titleText: "Geocoder",
+        searchText: "Search",
+        searchTpText: "Search selected location and zoom in on map",
+        resetText: "Reset",
+        resetTpText: "Reset location search",
+        translatedKeys: {
+            "name": "Street",
+            "number": "Number"
+        }
     }
 });

--- a/mapcomposer/app/static/translations/es.js
+++ b/mapcomposer/app/static/translations/es.js
@@ -627,7 +627,8 @@ GeoExt.Lang.add("es", {
     
     "gxp.plugins.spatialselector.SpatialSelectorMethod.prototype" :{
         areaLabel: "Área",  
-        perimeterLabel: "Perímetro",    
+        perimeterLabel: "Perímetro", 
+        lengthLabel: "Longitud",   
         radiusLabel: "Radio",   
         centroidLabel: "Centroide", 
         selectionSummary: "Sumario de la Selección"
@@ -682,5 +683,17 @@ GeoExt.Lang.add("es", {
     "gxp.plugins.spatialselector.PolygonSpatialSelectorMethod.prototype" :{
         name  : 'Polígono',
         label : 'Polígono'
+    },
+    
+    "gxp.plugins.spatialselector.Geocoder.prototype" :{
+        titleText: "Callejero",
+        searchText: "Buscar",
+        searchTpText: "Localiza la dirección en el mapa",
+        resetText: "Reiniciar",
+        resetTpText: "Reinicia la búsqueda por localización",
+        translatedKeys: {
+            "name": "Calle",
+            "number": "Número"
+        }
     }
 });

--- a/mapcomposer/app/static/translations/it.js
+++ b/mapcomposer/app/static/translations/it.js
@@ -693,6 +693,7 @@ GeoExt.Lang.add("it", {
     "gxp.plugins.spatialselector.SpatialSelectorMethod.prototype" :{
         areaLabel : "Area",
         perimeterLabel : "Perimetro",
+        lengthLabel: "Lunghezza",
         radiusLabel : "Raggio",
         centroidLabel : "Centroide",
         selectionSummary: "Sommario delle Selezioni"

--- a/mapcomposer/buildjs.cfg
+++ b/mapcomposer/buildjs.cfg
@@ -218,6 +218,7 @@ include =
     plugins/spatialselector/GeocoderSpatialSelectorMethod.js
     plugins/spatialselector/SpatialSelector.js
     plugins/SpatialSelectorQueryForm.js
+    plugins/spatialselector/Geocoder.js
 	plugins/SaveDefaultContext.js
     plugins/LayerProperties.js
     plugins/ZoomToLayerExtent.js


### PR DESCRIPTION
- New widget to perform WFS querys in cascade using geocoding spatial selectors.
- Append `ignoreExtraDims` on wfs search combo
- Make WFS search combo output format configurable.
- Add option on the Geocoder spatial selector to select different output format for the WFS search combo.
- Add `es` and `en` translations for this Geocoder.
- Minor fixes on feature summaries on spatial selectors

You can see [proposal page](https://github.com/geosolutions-it/MapStore/wiki/Proposal-%235:-Geocoder-based-on-WFS-spatial-selectors)
