### PR TITLE
Ilike filter for attribute builder

### DIFF
--- a/mapcomposer/app/static/externals/gxp/src/script/widgets/form/ComparisonComboBox.js
+++ b/mapcomposer/app/static/externals/gxp/src/script/widgets/form/ComparisonComboBox.js
@@ -28,7 +28,9 @@ gxp.form.ComparisonComboBox = Ext.extend(Ext.form.ComboBox, {
         [OpenLayers.Filter.Comparison.GREATER_THAN, ">"],
         [OpenLayers.Filter.Comparison.LESS_THAN_OR_EQUAL_TO, "<="],
         [OpenLayers.Filter.Comparison.GREATER_THAN_OR_EQUAL_TO, ">="],
-        [OpenLayers.Filter.Comparison.LIKE, "like"]
+        [OpenLayers.Filter.Comparison.LIKE, "like"],
+        // simulate ilike operator (not match case)
+        ["ilike", "ilike"]
     ],
 
     allowBlank: false,

--- a/mapcomposer/app/static/externals/gxp/src/script/widgets/form/FilterField.js
+++ b/mapcomposer/app/static/externals/gxp/src/script/widgets/form/FilterField.js
@@ -146,6 +146,14 @@ gxp.form.FilterField = Ext.extend(Ext.form.CompositeField, {
                     select: function(combo, record) {
                         this.items.get(2).enable();
                         this.filter.type = record.get("value");
+                        // Ilike (ignore case)
+                        if(this.filter.type == "ilike"){
+                            this.filter.type = OpenLayers.Filter.Comparison.LIKE;
+                            this.filter.matchCase = false;
+                        }else{
+                            // default matches case. See OpenLayers.Filter.Comparison#matchCase
+                            this.filter.matchCase = true;
+                        }
                         this.fireEvent("change", this.filter);
                     },
                     scope: this


### PR DESCRIPTION
Simulate `ilike` operator for the attribute filter builder on query form. We play with the `matchCase` parameter of `OpenLayers.Filter.Comparison`
