### PR TITLE
Pluggable admin UI and load changes

### DIFF
--- a/mapcomposer/app/static/config/defaultTemplate.js
+++ b/mapcomposer/app/static/config/defaultTemplate.js
@@ -1,0 +1,21 @@
+{
+    "footer": {
+        "container": {}
+    }, 
+    "header": {
+        "container": {
+            "animCollapse": false, 
+            "border": false, 
+            "collapseMode": "mini", 
+            "collapsible": true, 
+            "header": false, 
+            "height": 140, 
+            "hideCollapseTool": true, 
+            "maxHeight": 140, 
+            "minHeight": 140, 
+            "split": true
+        }, 
+        "css": "<style type='text/css'>div.topbanner{background-image: url(theme/app/img/banner/world-home.jpg);background-repeat:no-repeat;background-color:black;background-position:center top;height:100%;}div.topbanner .logo-gs-white{float:left;padding-top:25px;}div.topbanner .logo-ms-white{color: #33e366;font-family:'Verdana';font-style: oblique;font-size: 20px;font-weight: bold;float: right;padding-top: 50px;left: 10px;}</style>", 
+        "html": "<div class='topbanner'><div class='logo-gs-white'><a href='http://www.geo-solutions.it/'><img src='theme/app/img/banner/geosolutions-logo-whitebg.png' alt='GeoSolutions'></a></div></div>"
+    }
+}

--- a/mapcomposer/app/static/config/managerConfig.js
+++ b/mapcomposer/app/static/config/managerConfig.js
@@ -34,6 +34,56 @@
          "Español"
       ]
    ],
+   "tools":[{
+        "ptype": "mxp_mapmanager",
+        "loginManager": "loginTool",
+        "actionTarget":null
+    },{
+        "ptype": "mxp_login",
+        "pluginId": "loginTool",
+        "actionTarget":{
+          "target": "north.tbar",
+          "index": 2
+        }
+    },{
+        "ptype": "mxp_languageselector",
+        "actionTarget":{
+          "target": "north.tbar",
+          "index": 6
+        }
+    }],
+   "loggedTools":[{
+        "ptype": "mxp_mapmanager",
+        "loginManager": "loginTool",
+        "actionTarget": null
+    },{
+        "ptype": "mxp_templatemanager",
+        "loginManager": "loginTool",
+        "actionTarget":{
+          "target": "north.tbar",
+          "index": 0 
+        }
+    },{
+        "ptype": "mxp_usermanager",
+        "loginManager": "loginTool",
+        "actionTarget":{
+          "target": "north.tbar",
+          "index": 1 
+        }
+    },{
+        "ptype": "mxp_login",
+        "pluginId": "loginTool",
+        "actionTarget":{
+          "target": "north.tbar",
+          "index": 4
+        }
+    },{
+        "ptype": "mxp_languageselector",
+        "actionTarget":{
+          "target": "north.tbar",
+          "index": 8
+        }
+    }],
    "embedLink": {
 		"embeddedTemplateName": "viewer",
 		"showDirectURL": true,

--- a/mapcomposer/app/static/config/mapStoreConfig.js
+++ b/mapcomposer/app/static/config/mapStoreConfig.js
@@ -1,33 +1,4 @@
 {
-   "header": {
-	   "html": "<div class='topbanner'><div class='logo-gs-white'><a href='http://www.geo-solutions.it/'><img src='theme/app/img/banner/geosolutions-logo-whitebg.png' alt='GeoSolutions'></a></div></div>",
-	   "css": "<style type='text/css'>div.topbanner{background-image: url(theme/app/img/banner/world-home.jpg);background-repeat:no-repeat;background-color:black;background-position:center top;height:100%;}div.topbanner .logo-gs-white{float:left;padding-top:25px;}div.topbanner .logo-ms-white{color: #33e366;font-family:'Verdana';font-style: oblique;font-size: 20px;font-weight: bold;float: right;padding-top: 50px;left: 10px;}</style>",
-	   "container": {
-			"border": false,
-			"header": false,
-			"collapsible": true,
-			"collapseMode":  "mini",
-			"hideCollapseTool": true,
-			"split": true,
-			"animCollapse": false,
-			"minHeight": 140,
-			"maxHeight": 140,
-			"height": 140
-	   }
-   },
-   
-   "footer": {
-		"html": "",
-		"css": "",
-		"container": {
-			"border": false,
-			"header": false,
-			"split": true,
-			"minHeight": 50,
-			"maxHeight": 50,
-			"height": 50
-		}
-   },
    
    "advancedScaleOverlay": false,
    "gsSources":{ 

--- a/mapcomposer/app/static/externals/gxp/src/script/GeoExplorerLoader.js
+++ b/mapcomposer/app/static/externals/gxp/src/script/GeoExplorerLoader.js
@@ -1,0 +1,274 @@
+/*
+ *  Copyright (C) 2007 - 2014 GeoSolutions S.A.S.
+ *  http://www.geo-solutions.it
+ *
+ *  GPLv3 + Classpath exception
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+
+/**
+ * api: (define)
+ * module = GeoExplorerLoader
+ * extends = Ext.util.Observable
+ *  base_link = `Ext.util.Observable <http://extjs.com/deploy/dev/docs/?class=Ext.util.Observable>`_
+ */
+
+/** api: constructor
+ *  .. class:: GeoExplorerLoader(config)
+ *     Prepare a GeoExplorer configuration based on some custom configurations
+ */
+var GeoExplorerLoader = Ext.extend(Ext.util.Observable, {  
+   
+
+    /** private: method[constructor]
+     */
+    constructor: function(config, customConfigName, mapStoreDebug, mapId, auth, fScreen, templateId) {
+
+        this.config = config || {};
+        this.mapId = mapId;
+        this.auth = auth ? decodeURI(auth): null;
+        this.fScreen = fScreen;
+        this.templateId = templateId;
+        this.geoStoreBaseURL = config != null && config.geoStoreBaseURL ? config.geoStoreBaseURL : ('http://' + window.location.host + '/geostore/rest/');
+        this.mapStoreDebug = mapStoreDebug;
+        this.proxy = "";
+        
+        this.addEvents(
+            /** api: event[loaddefaultconfig]
+             *  Fired when the default configuration is loaded.
+             *
+             *  Listener arguments:
+             *  * config - :class:`Object` the configuration loaded
+             */
+            "loaddefaultconfig",
+            /** api: event[loadtemplateconfig]
+             *  Fired when the template configuration is loaded.
+             *
+             *  Listener arguments:
+             *  * config - :class:`Object` the configuration loaded
+             */
+            "loadtemplateconfig",
+            /** api: event[configfinished]
+             *  Fired when the all configurations are loaded.
+             *
+             *  Listener arguments:
+             *  * config - :class:`Object` the configuration loaded
+             */
+            "configfinished"
+        );
+            
+        GeoExplorerLoader.superclass.constructor.apply(this, arguments);
+
+        this.loadDefaultConfig(customConfigName, mapStoreDebug);
+    },
+
+    /** private: method[loadDefaultConfig]
+     *  Load default configuration
+     */
+    loadDefaultConfig: function(customConfigName, mapStoreDebug){
+        var serverConfig = this.config;
+        var templateId = this.templateId;
+
+        this.on("loaddefaultconfig", function(config){
+            Ext.apply(this.config, config);
+            this.geoStoreBaseURL = config != null && config.geoStoreBase ? config.geoStoreBase : this.geoStoreBaseURL;
+            this.proxy = this.mapStoreDebug === true ? "/proxy/?url=" : config.proxy ? config.proxy : "";
+            this.loadTemplateConfig();
+        });
+
+        this.loadData(customConfigName ? "config/" + customConfigName + ".js"  : "config/mapStoreConfig.js", null, "loaddefaultconfig");      
+    },
+
+    /** private: method[loadTemplateConfig]
+     *  Load template configuration
+     */
+    loadTemplateConfig: function(){
+        var serverConfig = this.config;
+        var templateId = this.templateId;
+
+        if(templateId){
+            this.on("loadtemplateconfig", function(config){
+                Ext.apply(this.config, config);
+                this.loadCustomConfigs();
+            });
+            // template can be a config file or a geostore resource
+            if(typeof(templateId) == "number"){
+                this.loadData(null, templateId, "loadtemplateconfig");
+            }else{
+                this.loadData("config/" + templateId + ".js", null, "loadtemplateconfig");
+            }
+        }else{
+            this.loadCustomConfigs();
+        }
+
+    },
+
+    /** private: method[loadCustomConfigs]
+     *  Load existing configs available for the user logged/GUEST
+     */
+    loadCustomConfigs: function(){
+        var config = this.config;
+        var me = this;
+        var url = this.geoStoreBaseURL + 'extjs/search/category/MAPSTORECONFIG';
+        if(url.indexOf("http") == 0){
+            url = this.proxy + url;
+        }
+        this.adminConfigStore = new Ext.data.JsonStore({
+            root: 'results',
+            autoLoad: false,
+            totalProperty: 'totalCount',
+            successProperty: 'success',
+            idProperty: 'id',
+            fields: [
+                'id',
+                'name'
+            ],
+            proxy: new Ext.data.HttpProxy({
+                url: url,
+                restful: true,
+                method : 'GET',
+                disableCaching: true,
+                failure: function (response) {
+                    // no custom configs available
+                    me.fireEvent("configfinished", config);                                
+                }
+            }),
+            listeners:{
+                load: this.adminConfigLoad,
+                scope: this
+            }
+        });
+        this.adminConfigStore.proxy.getConnection().defaultHeaders= {
+            'Accept': 'application/json', 
+            'Authorization' : this.auth
+        };
+        this.adminConfigStore.load();
+    },
+
+    /** private: method[adminConfigLoad]
+     *  Load the admin config from the configuration present on the store
+     */
+    adminConfigLoad: function(store){
+        if(store && store.getCount && store.getCount() > 0){
+            var pendingConfig = store.getCount();
+            // config is this.config
+            var config = this.config;
+            // default tools
+            var tools = [];
+            this.on("loadcustomconfig", function(customConfig){
+                pendingConfig--;
+                if(customConfig && customConfig instanceof Object){
+                    for(var key in customConfig) {
+                        if(!config[key]){
+                            config[key] = customConfig[key];
+                        }else if(config[key] instanceof Array){
+                            config[key] = this.addAll(customConfig[key], config[key]);
+                        }else if(config[key] instanceof Object){
+                            Ext.apply(config[key], customConfig[key]);
+                        }else{
+                            config[key] = customConfig[key];
+                        }
+                    }   
+                }
+                this.applyUserConfig(pendingConfig, config);
+            });
+            store.each(function(item){
+                this.loadData(null, item.get("id"), "loadcustomconfig");
+            }, this);
+        }else{
+            this.fireEvent("configfinished", config);
+        }
+    },
+
+    /** private: method[loadData]
+     *  Load a configuration from an url
+     */
+    loadData: function (url, dataId, eventListener){
+        var url = (url ? url: this.geoStoreBaseURL + "data/" + dataId);
+        if(url.indexOf("http") == 0){
+            url = this.proxy + url;
+        }
+        Ext.Ajax.request({
+            method: 'GET',
+            scope: this,
+            url: url,
+            success: function(response, opts){
+                try{
+                    var loadedConfig = Ext.util.JSON.decode(response.responseText);
+                    this.fireEvent(eventListener, loadedConfig);
+                }catch(e){
+                    console.error("Error getting config");
+                    this.fireEvent(eventListener, {});
+                }
+            },
+            failure:  function(response, opts){
+                console.error("Error getting config");
+                    this.fireEvent(eventListener, {});
+            }
+        });
+    },
+
+    /** private: method[addAll]
+     */
+    addAll: function(toAdd, target){
+        var componentsNotPresent = [];
+        if(toAdd instanceof Array){
+            for(var i = 0; i < toAdd.length; i++){
+                if(!this.isAlreadyPresent(toAdd[i], target)){
+                    componentsNotPresent.push(toAdd[i]);
+                }
+            }   
+        }else if(toAdd instanceof Object){
+            if(!this.isAlreadyPresent(toAdd, target)){
+                componentsNotPresent.push(toAdd);
+            }
+        }
+        return target.concat(componentsNotPresent);
+    },
+
+    /** private: method[isAlreadyPresent]
+     */
+    isAlreadyPresent: function(element, elements){
+        var isAlreadyPresent = false;
+        if(elements && element){
+            for(var i = 0; i < elements.length; i++){
+                if(isAlreadyPresent){
+                    break;
+                }else{
+                    isAlreadyPresent = true;   
+                }
+                for(var key in elements[i]){
+                    isAlreadyPresent = isAlreadyPresent && (element[key] == elements[i][key]);
+                    if(!isAlreadyPresent){
+                        break;
+                    }
+                }
+            }
+        }
+        return isAlreadyPresent;
+    },
+
+    /** private: method[applyUserConfig]
+     *  Apply tools available for logged user
+     */
+    applyUserConfig: function(pendingConfig, config){
+        if(pendingConfig == 0){
+            this.fireEvent("configfinished", config);
+        }
+    }
+
+});
+

--- a/mapcomposer/app/static/externals/mapmanager/src/Ext.ux/ImagePicker.js
+++ b/mapcomposer/app/static/externals/mapmanager/src/Ext.ux/ImagePicker.js
@@ -208,7 +208,7 @@ Ext.ux.ImagePicker = Ext.extend(Ext.FormPanel, {
      */
     getUploadUrl: function(){
         // Include proxy host for plupload (not ExtJS proxy supported)
-        var uploadURL = this.actionURL + "/../upload";
+        var uploadURL = this.actionURL.replace("extJSbrowser", "upload");
         var checkUrl = this.actionURL;
         var index0 = checkUrl.indexOf("://");
         if(index0 > -1){
@@ -217,7 +217,7 @@ Ext.ux.ImagePicker = Ext.extend(Ext.FormPanel, {
             var this_host = document.URL.split("://")[1];
             this_host = this_host.substring(0, this_host.indexOf("/"));
             if(checkUrl != this_host){
-                uploadURL =  OpenLayers.ProxyHost + this.actionURL + "/../upload"; 
+                uploadURL =  OpenLayers.ProxyHost + uploadURL; 
             }
         }
 

--- a/mapcomposer/app/static/externals/mapmanager/src/MSMLogin.js
+++ b/mapcomposer/app/static/externals/mapmanager/src/MSMLogin.js
@@ -109,6 +109,12 @@ MSMLogin = Ext.extend(Ext.FormPanel, {
      * 
      */
     defaultType:'textfield',
+    /**
+     * Property: statelessSession
+     * {Boolean} If the session is stateless is not needed check user details at startup
+     * 
+     */
+    statelessSession: true,
      
     /** private: method[constructor]
      */
@@ -136,25 +142,7 @@ MSMLogin = Ext.extend(Ext.FormPanel, {
         
         Ext.apply(this, {  
             monitorValid:true,
-            trackResetOnLoad : true,/*
-            errorReader: {
-                read: function(response) {
-                    var success = false;
-                    var records = [];
-                    if (response.status === 200) {
-                        success = true;
-                    } else {
-                        records = [
-                            {data: {id: "loginUsername", msg: this.loginErrorText}},
-                            {data: {id: "loginPassword", msg: this.loginErrorText}}
-                        ];
-                    }
-                    return {
-                        success: success,
-                        records: records
-                    };
-                }
-            },*/
+            trackResetOnLoad : true,
             items:[{  
                 fieldLabel: this.userFieldText,
                 name:'loginUsername', 
@@ -194,7 +182,18 @@ MSMLogin = Ext.extend(Ext.FormPanel, {
             cls: 'user-role-label'
         });
 
-        this.getLoginInformation();
+        if(!this.defaultHeaders){
+            this.defaultHeaders = {
+                'Accept': 'application/json',
+                'Authorization': this.token
+            };
+        }
+
+        if(!this.statelessSession || this.token){
+            this.getLoginInformation();   
+        }else{
+            this.showLogin();
+        }
         
         MSMLogin.superclass.initComponent.call(this, arguments);
     },
@@ -208,9 +207,7 @@ MSMLogin = Ext.extend(Ext.FormPanel, {
             method: 'GET',
             url: this.geoStoreBase + 'users/user/details/',
             scope: this,
-            headers: {
-                'Accept': 'application/json'
-            },
+            headers: this.defaultHeaders,
             success: function(response, form, action) {
                 
                 var user = Ext.util.JSON.decode(response.responseText);
@@ -219,17 +216,10 @@ MSMLogin = Ext.extend(Ext.FormPanel, {
                     this.username = user.User.name;
                     this.role = user.User.role;
                     this.showLogout(user.User.name);
-                    this.grid.render();
-                    this.grid.store.proxy.getConnection().defaultHeaders = {'Accept': 'application/json'};                
-                    this.grid.getBottomToolbar().bindStore(this.grid.store, true);
-                    this.grid.getBottomToolbar().doRefresh();
-                    this.grid.plugins.collapseAll();
-                    this.grid.getBottomToolbar().openMapComposer.enable();
-                    this.grid.openUserManagerButton.enable();
                     this.fireEvent("login", this.username);
                 }else{
                     // invalid user state
-                    this.showLogin();            
+                    this.showLogin();
                 }
             },
             failure: function(response, form, action) {
@@ -272,25 +262,22 @@ MSMLogin = Ext.extend(Ext.FormPanel, {
      *  Log out the current user from the application.
      */
     logout: function() {
-
-        // Remove authorization token
-        this.grid.store.proxy.getConnection().defaultHeaders = {
-            "Accept": "application/json", 
-            "Authorization": null
-        };
-
-        // do logout in spring security
-        Ext.Ajax.request({
-            method: 'GET',
-            url: this.geoStoreBase.replace("/rest/", "/j_spring_security_logout"),
-            scope: this,
-            success: function(response, form, action) {
-                this.invalidateLoginState();
-            },
-            failure: function(response, form, action) {
-                this.invalidateLoginState();
-            }
-        });
+        if(this.statelessSession){
+            this.invalidateLoginState();
+        }else{
+            // do logout in spring security
+            Ext.Ajax.request({
+                method: 'GET',
+                url: this.geoStoreBase.replace("/rest/", "/j_spring_security_logout"),
+                scope: this,
+                success: function(response, form, action) {
+                    this.invalidateLoginState();
+                },
+                failure: function(response, form, action) {
+                    this.invalidateLoginState();
+                }
+            });
+        }
     },
     
     /** private: method[invalidateLoginState]
@@ -301,12 +288,7 @@ MSMLogin = Ext.extend(Ext.FormPanel, {
         this.token = null;
         this.userid = null;
         this.username = null;
-        this.grid.getBottomToolbar().bindStore(this.grid.store, true);
-        this.grid.getBottomToolbar().doRefresh();
-        this.grid.plugins.collapseAll()
-        this.grid.getBottomToolbar().openMapComposer.disable();
-        this.grid.openUserManagerButton.disable();
-        this.showLogin();
+        this.showLogin(true);
     },
 
     /** 
@@ -344,6 +326,7 @@ MSMLogin = Ext.extend(Ext.FormPanel, {
         var pass = fields.loginPassword;
         var user = fields.loginUsername;
         var auth= 'Basic ' + Base64.encode(user+':'+pass);
+
         Ext.Ajax.request({
             method: 'GET',
             url: this.geoStoreBase + 'users/user/details/',
@@ -367,14 +350,7 @@ MSMLogin = Ext.extend(Ext.FormPanel, {
 					this.username = user.User.name;
 					this.role = user.User.role;
 				}
-				this.grid.render();
-                this.grid.store.proxy.getConnection().defaultHeaders = {'Accept': 'application/json', "Authorization": auth};                
-                this.grid.getBottomToolbar().bindStore(this.grid.store, true);
-                this.grid.getBottomToolbar().doRefresh();
-                this.grid.plugins.collapseAll();
-                this.grid.getBottomToolbar().openMapComposer.enable();
-				this.grid.openUserManagerButton.enable();
-                this.fireEvent("login", this.username);
+                this.fireEvent("login", this.username, auth);
             },
             failure: function(response, form, action) {
                 Ext.MessageBox.show({

--- a/mapcomposer/app/static/externals/mapmanager/src/MSMPagingToolbar.js
+++ b/mapcomposer/app/static/externals/mapmanager/src/MSMPagingToolbar.js
@@ -190,6 +190,19 @@ MSMPagingToolbar = Ext.extend(Ext.PagingToolbar, {
     * 
     */
     addMapControls: true,
+
+    /** i18n **/
+    createMapText: "Create",
+    createMapTitleText: "Create a new map",
+    templateSeleccionErrorText: "Please select a template before create the map",
+    templateText: "Template",
+    
+    /**
+    * Property: checkTemplateId
+    * {boolean} Check if you must select a template id. Default it's false.
+    * 
+    */
+    checkTemplateId: false,
 	
     /**
      * Method: initComponent
@@ -258,13 +271,8 @@ MSMPagingToolbar = Ext.extend(Ext.PagingToolbar, {
         }
     },
 
-    createMapText: "Create",
-    createMapTitleText: "Create a new map",
-    templateSeleccionErrorText: "Please select a template before create the map",
-    templateText: "Template",
-
     onAddMap: function(){
-        var userProfile = '&auth=true';
+        var userProfile = '&auth=' + (this.grid.auth ? encodeURI(this.grid.auth) : "false");
         var idMap = -1;
         var me = this;
         
@@ -295,7 +303,7 @@ MSMPagingToolbar = Ext.extend(Ext.PagingToolbar, {
                         handler: function(){      
                             var templateId = win.formPanel.templateCombo.getValue();
 
-                            if(templateId){
+                            if(!this.checkTemplateId || (this.checkTemplateId && templateId)){
                                 win.hide(); 
         
                                 this.grid.plugins.openMapComposer(this.grid.murl, userProfile, idMap, this.desc, templateId);

--- a/mapcomposer/app/static/externals/mapmanager/src/MSMTemplateComboBox.js
+++ b/mapcomposer/app/static/externals/mapmanager/src/MSMTemplateComboBox.js
@@ -79,6 +79,11 @@
 	        	scope: this
 	        }
     	};
+    	
+        this.store.proxy.getConnection().defaultHeaders = {
+            'Accept': 'application/json', 
+            'Authorization' : this.auth
+        };
 		
         MSMTemplateComboBox.superclass.initComponent.call(this, arguments);
 	}

--- a/mapcomposer/app/static/externals/mapmanager/src/MSMTemplateGridPanel.js
+++ b/mapcomposer/app/static/externals/mapmanager/src/MSMTemplateGridPanel.js
@@ -132,6 +132,10 @@ MSMTemplateGridPanel = Ext.extend(Ext.grid.GridPanel, {
             
             sortInfo: { field: "name", direction: "ASC" }
 		 });
+        store.proxy.getConnection().defaultHeaders = {
+            'Accept': 'application/json', 
+            'Authorization' : this.auth
+        };
 
 		var expander = new Ext.ux.grid.RowExpander({
             /**

--- a/mapcomposer/app/static/externals/mapmanager/src/MSMTemplateManager.js
+++ b/mapcomposer/app/static/externals/mapmanager/src/MSMTemplateManager.js
@@ -28,6 +28,9 @@
  */
 MSMTemplateManager = Ext.extend(Ext.form.FormPanel, {
 
+ 	/** xtype = msm_templatemanager **/
+    xtype: "msm_templatemanager",
+
 	title: 'Template manager',
     
     /** api: config[adminUrl]
@@ -142,7 +145,7 @@ MSMTemplateManager = Ext.extend(Ext.form.FormPanel, {
 	    			formContainer: this,
 	    			login: this.login,
 	    			geoStoreBase: this.geoStoreBase,
-	    			actionURL: this.adminUrl + "fileManager/extJSbrowser",
+	    			actionURL: this.adminUrl + "mvc/fileManager/extJSbrowser",
 	    			listeners:{
 	    				success: function(){
 	    					// refresh the grid
@@ -202,3 +205,6 @@ MSMTemplateManager = Ext.extend(Ext.form.FormPanel, {
 		});
     }
 });
+
+/** api: xtype = msm_templatemanager */
+Ext.reg(MSMTemplateManager.prototype.xtype, MSMTemplateManager);

--- a/mapcomposer/app/static/externals/mapmanager/src/MSMTemplatePanel.js
+++ b/mapcomposer/app/static/externals/mapmanager/src/MSMTemplatePanel.js
@@ -85,7 +85,7 @@ MSMTemplatePanel = Ext.extend(Ext.Panel, {
      *  ``String``
      *  URL to the extJSbrowser of OpenSDI-Manager2
      */
-    actionURL: "/opensdi2-manager/fileManager/extJSbrowser",
+    actionURL: "/opensdi2-manager/mvc/fileManager/extJSbrowser",
 
     /**
     * Constructor: initComponent 

--- a/mapcomposer/app/static/externals/mapmanager/src/MSMUserManager.js
+++ b/mapcomposer/app/static/externals/mapmanager/src/MSMUserManager.js
@@ -27,6 +27,9 @@
  */
 UserManagerView = Ext.extend(
 		Ext.grid.GridPanel, {
+
+		 	/** xtype = msm_usermanager **/
+		    xtype: "msm_usermanager",
 			
 			/**
 		     * Property: id
@@ -593,6 +596,8 @@ UserManagerView = Ext.extend(
 							  title: userManager.textEditUserTitle,
 							  iconCls: userManager.iconCls,
 							  frame:true,  border:false,
+				              closable: true,
+				              closeAction: 'close',
 							  id: userManager.id,
 							  items: [{
 									  xtype: 'fieldset',
@@ -965,3 +970,6 @@ UserManagerView = Ext.extend(
 		    border:false
 		  		
 	    });
+
+/** api: xtype = msm_usermanager */
+Ext.reg(UserManagerView.prototype.xtype, UserManagerView);

--- a/mapcomposer/app/static/externals/mapmanager/src/MSMUtil.js
+++ b/mapcomposer/app/static/externals/mapmanager/src/MSMUtil.js
@@ -342,8 +342,15 @@
 		var data = this.beforeSave(item);
 		var uri = new Uri({'url':this.baseUrl_});
 		uri.appendPath( this.resourceNamePrefix_ ).appendId( pk );
+
+		// remove appended "?" without parameters
+		var url = uri.toString();
+		if(url.indexOf("?") == url.length - 1){
+			url = url.replace("?", "");
+		}
+
 		var Request = Ext.Ajax.request({
-	       url: uri.toString(),
+	       url: url,
 	       method: 'PUT',
 	       headers: {
 	          'Content-Type' : 'text/xml',
@@ -358,7 +365,7 @@
 	       failure:  function(response, opts){
 				this.onFailure_(response);
 	       }
-	    });		
+	    });
 	};	
 	
 	/** 
@@ -374,8 +381,15 @@
 	ContentProvider.prototype.deleteByPk = function(pk, callback){
 		var uri = new Uri({'url':this.baseUrl_});
 		uri.appendPath( this.resourceNamePrefix_ ).appendId( pk );
+
+		// remove appended "?" without parameters
+		var url = uri.toString();
+		if(url.indexOf("?") == url.length - 1){
+			url = url.replace("?", "");
+		}
+
 		var Request = Ext.Ajax.request({
-	       url: uri.toString(),
+	       url: url,
 	       method: 'DELETE',
 	       headers:{
 	          'Content-Type' : 'application/json',
@@ -407,12 +421,18 @@
 	ContentProvider.prototype.create = function(item, callback, failureCallback){
 		var uri = new Uri({'url':this.baseUrl_});
 		var data = this.beforeSave( item );
+
+		// remove appended "?" without parameters
+		var url = uri.toString();
+		if(url.indexOf("?") == url.length - 1){
+			url = url.replace("?", "");
+		}
 		
 		// ///////////////////////////////
 		// Build the Ajax request
 		// ///////////////////////////////
 		var Request = Ext.Ajax.request({
-	       url: uri.toString(),
+	       url: url,
 	       method: 'POST',
 	       headers:{
 	          'Content-Type' : 'text/xml',

--- a/mapcomposer/app/static/externals/mapmanager/src/mxp/plugins/LanguageSelector.js
+++ b/mapcomposer/app/static/externals/mapmanager/src/mxp/plugins/LanguageSelector.js
@@ -1,0 +1,83 @@
+/*
+ *  Copyright (C) 2007 - 2014 GeoSolutions S.A.S.
+ *  http://www.geo-solutions.it
+ *
+ *  GPLv3 + Classpath exception
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+ 
+/** api: (define)
+ *  module = mxp.plugins
+ *  class = LanguageSelector
+ */
+Ext.ns("mxp.plugins");
+
+/** api: constructor
+ *  .. class:: LanguageSelector(config)
+ *
+ *    Simple languague selector for SN Manager
+ */
+mxp.plugins.LanguageSelector = Ext.extend(mxp.plugins.Tool, {
+    
+    /** api: ptype = mxp_languageselector */
+    ptype: "mxp_languageselector",
+
+    /** api: method[addActions]
+     */
+    addActions: function() {
+
+        code = this.target.config.code;
+
+        return mxp.plugins.LanguageSelector.superclass.addActions.apply(this, [new Ext.form.ComboBox({
+            store: new Ext.data.ArrayStore({
+                fields: ['code', 'name'],
+                data :  this.target.config.langData
+            }),
+            emptyText: this.target.config.initialLanguageString,
+            displayField: 'name',
+            typeAhead: true,
+            mode: 'local',
+            forceSelection: true,
+            triggerAction: 'all',
+            selectOnFocus:false,
+            editable: false,
+            width: 100,
+            listeners: {
+                beforeselect: function(cb, record, index){
+                   if(code == record.get('code')){
+                        return false;
+                   }
+                },                    
+                select: function(cb, record, index) {         
+                   var code = record.get('code');
+                
+                   var query = location.search;        
+                   if(query && query.substr(0,1) === "?"){
+                        query = query.substring(1);
+                   }  
+                   
+                   var url = Ext.urlDecode(query);
+
+                   if(code){
+                       location.replace(
+                           location.pathname + '?locale=' + code);                                   
+                   }
+                }
+            }
+        })]);
+    }
+});
+
+Ext.preg(mxp.plugins.LanguageSelector.prototype.ptype, mxp.plugins.LanguageSelector);

--- a/mapcomposer/app/static/externals/mapmanager/src/mxp/plugins/Login.js
+++ b/mapcomposer/app/static/externals/mapmanager/src/mxp/plugins/Login.js
@@ -1,0 +1,84 @@
+/*
+ *  Copyright (C) 2007 - 2014 GeoSolutions S.A.S.
+ *  http://www.geo-solutions.it
+ *
+ *  GPLv3 + Classpath exception
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+ 
+/** api: (define)
+ *  module = mxp.plugins
+ *  class = Login
+ */
+Ext.ns("mxp.plugins");
+
+/** api: constructor
+ *  .. class:: Login(config)
+ *
+ *    Login Plugin
+ */
+mxp.plugins.Login = Ext.extend(mxp.plugins.Tool, {
+    
+    /** api: ptype = mxp_login */
+    ptype: "mxp_login",
+
+    buttonText: "Login",
+
+    /** api: method[addActions]
+     */
+    addActions: function() {
+        
+        // ///////////////////////////////////
+        // Inizialization of MSMLogin class
+        // ///////////////////////////////////
+        this.login = new MSMLogin({
+            // grid: this,
+            geoStoreBase : this.target.config.geoStoreBase,
+            token: this.target.auth,
+            defaultHeaders: this.target.defaultHeaders
+        });
+
+        // Add listeners for login and logout
+        this.login.on("login", this.onLogin, this);
+        this.login.on("logout", this.onLogout, this);
+
+
+
+        var actions = [
+            this.login.userLabel,
+            Ext.create({xtype: 'tbseparator'}),
+            this.login.loginButton];
+
+        return mxp.plugins.TemplateManager.superclass.addActions.apply(this, [actions]);
+    },
+
+    /** private: method[onLogin]
+     *  Listener with actions to be executed when an user makes login.
+     */
+    onLogin: function(user, auth){
+        this.target.onLogin(user, auth);
+        this.fireEvent("login", user, auth);
+    },
+
+    /** private: method[onLogout]
+     *  Listener with actions to be executed when an user makes logout.
+     */
+    onLogout: function(){
+        this.target.onLogout();
+        this.fireEvent("logout");
+    }
+});
+
+Ext.preg(mxp.plugins.Login.prototype.ptype, mxp.plugins.Login);

--- a/mapcomposer/app/static/externals/mapmanager/src/mxp/plugins/MapManager.js
+++ b/mapcomposer/app/static/externals/mapmanager/src/mxp/plugins/MapManager.js
@@ -1,0 +1,196 @@
+/*
+ *  Copyright (C) 2007 - 2014 GeoSolutions S.A.S.
+ *  http://www.geo-solutions.it
+ *
+ *  GPLv3 + Classpath exception
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+ 
+/** api: (define)
+ *  module = mxp.plugins
+ *  class = MapManager
+ */
+Ext.ns("mxp.plugins");
+
+/** api: constructor
+ *  .. class:: MapManager(config)
+ *
+ *    Open the map manager
+ */
+mxp.plugins.MapManager = Ext.extend(mxp.plugins.Tool, {
+    
+    /** api: ptype = mxp_mapmanager */
+    ptype: "mxp_mapmanager",
+
+    buttonText: "Map manager",
+    tooltipText: "Open map manager",
+
+    loginManager: null, 
+
+    setActiveOnOutput: true,
+
+    // default configuration for the output
+    outputConfig: {
+        renderMapToTab: 'mainTabPanel',
+        adminPanelsTargetTab : 'mainTabPanel',
+        viewConfig: {
+            forceFit: true
+        }       
+    },
+
+    /** api: method[addActions]
+     */
+    addActions: function() {
+        
+        var thisButton = new Ext.Button({
+            text: this.buttonText,
+            tooltip: this.tooltipText,
+            handler: function() { 
+            	this.addOutput();                        
+            },
+            scope: this
+        });
+
+        var actions = [thisButton];
+        // var actions = [];
+
+        return mxp.plugins.MapManager.superclass.addActions.apply(this, [actions]);
+
+        this.addOutput(this);
+    },
+    
+    /** api: method[addOutput]
+     *  :arg config: ``Object`` configuration for the ``Ext.Component`` to be
+     *      added to the ``outputTarget``. Properties of this configuration
+     *      will be overridden by the applications ``outputConfig`` for the
+     *      tool instance.
+     *  :return: ``Ext.Component`` The component added to the ``outputTarget``. 
+     *
+     *  Adds output to the tool's ``outputTarget``. This method is meant to be
+     *  called and/or overridden by subclasses.
+     */
+    addOutput: function(config) {
+
+        var login = this.target.login ? this.target.login: 
+                this.loginManager && this.target.currentTools[this.loginManager] 
+                ? this.target.currentTools[this.loginManager] : null;
+
+        // create a map manager panel
+    	Ext.apply(this.outputConfig, {
+            xtype: 'msm_mapgrid',
+            iconCls: "server_map",
+            title: this.buttonText,
+            start: this.target.config.start,
+            limit: this.target.config.limit,
+            msmTimeout:this.target.config.msmTimeout,
+            lang: this.target.config.lang,
+            config: this.target.config,
+            langSelector: this.target.config.langSelector,
+            ASSET: this.target.config.ASSET,
+            login: login.login,
+            auth: this.target.auth,
+            searchUrl: this.target.geoSearchUsersUrl,
+            url: this.target.geoBaseUsersUrl,
+            geoStoreBase: this.target.config.geoStoreBase
+    	});
+
+        // apply headers on grid
+        this.on("outputadded", this.applyLoggedState, this);
+
+        // apply login state on grid
+        if(login && !login.login){
+            login.on("actionsadded", function(login){
+                this.login = login;
+                login.on("login", this.applyLoggin, this);
+                login.on("logout", this.applyLoggin, this);
+            }, this);
+        }
+
+        return mxp.plugins.MapManager.superclass.addOutput.apply(this, arguments);
+    },
+    
+    /** api: method[applyLoggin]
+     *  If an user is logged, apply user information to the grid
+     */
+    applyLoggin: function(username){
+        if(this.output){
+            for(var i = 0; i < this.output.length; i++){
+                this.output[i].login = this.login.login;
+                this.output[i].auth = this.login.login.getToken();
+
+                if(this.login.login && this.login.login.username){
+                    this.applyLoggedState(this.output[i]);
+                }
+            }
+        }
+    },
+    
+    /** api: method[applyLoggedState]
+     *  Apply target headers on grid
+     */
+    applyLoggedState: function(output){
+        if(output){
+            if(output.rendered && output.isVisible && output.isVisible()){
+                // rendered and visible
+                output.render();
+                output.store.proxy.getConnection().defaultHeaders = this.target.defaultHeaders;
+                output.getBottomToolbar().bindStore(output.store, true);
+                output.getBottomToolbar().doRefresh();
+                output.plugins.collapseAll();
+                if(this.target.auth){
+                    output.getBottomToolbar().openMapComposer.enable();
+                    output.openUserManagerButton.enable();
+                }else{
+                    output.getBottomToolbar().openMapComposer.disable();
+                    output.openUserManagerButton.disable();
+                }
+            }else{
+                // Tab not enabled, wait for activate
+                output.on("activate", function(){
+                    output.render();
+                    output.store.proxy.getConnection().defaultHeaders = this.target.defaultHeaders;
+                    output.getBottomToolbar().bindStore(output.store, true);
+                    output.getBottomToolbar().doRefresh();
+                    output.plugins.collapseAll();
+                    if(this.target.auth){
+                        output.getBottomToolbar().openMapComposer.enable();
+                        output.openUserManagerButton.enable();
+                    }else{
+                        output.getBottomToolbar().openMapComposer.disable();
+                        output.openUserManagerButton.disable();
+                    }
+                }, this);   
+            }
+        }
+    },
+    
+    /** api: method[remove]
+     *  Removes all actions and outputs created by this tool
+     */
+    remove: function() {
+
+        var login = this.target.login ? this.target.login: 
+                this.loginManager && this.target.currentTools[this.loginManager] 
+                ? this.target.currentTools[this.loginManager] : null;
+
+        login.removeListener("login", this.onLogin, this);
+        login.removeListener("logout", this.onLogout, this);
+        this.removeListener("outputadded", this.applyLoggedState, this);
+
+        return mxp.plugins.MapManager.superclass.remove.apply(this, arguments);
+    }
+});
+
+Ext.preg(mxp.plugins.MapManager.prototype.ptype, mxp.plugins.MapManager);

--- a/mapcomposer/app/static/externals/mapmanager/src/mxp/plugins/TemplateManager.js
+++ b/mapcomposer/app/static/externals/mapmanager/src/mxp/plugins/TemplateManager.js
@@ -1,0 +1,103 @@
+/*
+ *  Copyright (C) 2007 - 2014 GeoSolutions S.A.S.
+ *  http://www.geo-solutions.it
+ *
+ *  GPLv3 + Classpath exception
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+ 
+/** api: (define)
+ *  module = mxp.plugins
+ *  class = Tool
+ *  base_link = `Ext.util.Observable <http://extjs.com/deploy/dev/docs/?class=Ext.util.Observable>`_
+ */
+Ext.ns("mxp.plugins");
+
+/** api: constructor
+ *  .. class:: TemplateManager(config)
+ *
+ *    Open a template manager
+ */
+mxp.plugins.TemplateManager = Ext.extend(mxp.plugins.Tool, {
+    
+    /** api: ptype = mxp_templatemanager */
+    ptype: "mxp_templatemanager",
+
+    buttonText: "Templates",
+    tooltipText: "Open templates manager",
+
+    loginManager: null,    
+
+    setActiveOnOutput: true,
+
+    /** api: method[addActions]
+     */
+    addActions: function() {
+        
+        var thisButton = new Ext.Button({
+            text: this.buttonText,
+            tooltip: this.tooltipText,
+            handler: function() { 
+            	this.addOutput();                        
+            },
+            scope: this
+        });
+
+        var actions = [thisButton];
+
+        return mxp.plugins.TemplateManager.superclass.addActions.apply(this, [actions]);
+    },
+    
+    /** api: method[addOutput]
+     *  :arg config: ``Object`` configuration for the ``Ext.Component`` to be
+     *      added to the ``outputTarget``. Properties of this configuration
+     *      will be overridden by the applications ``outputConfig`` for the
+     *      tool instance.
+     *  :return: ``Ext.Component`` The component added to the ``outputTarget``. 
+     *
+     *  Adds output to the tool's ``outputTarget``. This method is meant to be
+     *  called and/or overridden by subclasses.
+     */
+    addOutput: function(config) {
+
+        var login = this.target.login ? this.target.login: 
+                this.loginManager && this.target.currentTools[this.loginManager] 
+                ? this.target.currentTools[this.loginManager] : null;
+
+        this.outputConfig = this.outputConfig || {};
+
+        // create a template manager panel
+        Ext.apply(this.outputConfig, {
+            xtype: "msm_templatemanager",
+            id: this.target.templateManagerId,
+            auth: this.target.auth,
+            login: login.login,
+            searchUrl: this.target.geoSearchCategoriesUrl,
+            url: this.target.geoBaseMapsUrl,
+            geoStoreBase: this.target.config.geoStoreBase,
+            closable: true,
+            closeAction: 'close'
+        });
+        if(this.target.config.adminUrl){
+            Ext.apply(this.outputConfig, {
+                adminUrl: this.target.config.adminUrl
+            }); 
+        }
+
+        return mxp.plugins.TemplateManager.superclass.addOutput.apply(this, arguments);
+    }
+});
+
+Ext.preg(mxp.plugins.TemplateManager.prototype.ptype, mxp.plugins.TemplateManager);

--- a/mapcomposer/app/static/externals/mapmanager/src/mxp/plugins/Tool.js
+++ b/mapcomposer/app/static/externals/mapmanager/src/mxp/plugins/Tool.js
@@ -1,0 +1,503 @@
+/*
+ *  Copyright (C) 2007 - 2014 GeoSolutions S.A.S.
+ *  http://www.geo-solutions.it
+ *
+ *  GPLv3 + Classpath exception
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+ 
+/** api: (define)
+ *  module = mxp.plugins
+ *  class = Tool
+ *  base_link = `Ext.util.Observable <http://extjs.com/deploy/dev/docs/?class=Ext.util.Observable>`_
+ */
+Ext.ns("mxp.plugins");
+
+/** api: constructor
+ *  .. class:: Tool(config)
+ *
+ *    Base class for plugins that add tool functionality to
+ *    :class:`mxp.widgets.SNManagerViewport`. These plugins are used by adding configuration 
+ *    objects for them to the ``tools`` array of the viewer's config object,
+ *    using their ``ptype``. Based on `gxp.plugins.Tool`.
+ */   
+mxp.plugins.Tool = Ext.extend(Ext.util.Observable, {
+    
+    /** api: ptype = mxp_tool */
+    ptype: "mxp_tool",
+    
+    /** api: config[autoActivate]
+     *  ``Boolean`` Set to false if the tool should be initialized without
+     *  activating it. Default is true.
+     */
+    autoActivate: true,
+    
+    /** api: property[active]
+     *  ``Boolean`` Is the tool currently active?
+     */
+
+    /** api: config[actions]
+     *  ``Array`` Custom actions for tools that do not provide their own. Array
+     *  elements are expected to be valid Ext config objects. Actions provided
+     *  here may have an additional ``menuText`` property, which will be used
+     *  as text when the action is used in a menu. The ``text`` property will
+     *  only be used in buttons. Optional, only needed to create custom
+     *  actions.
+     */
+    
+    /** api: config[setActiveOnOutput]
+     *  ``Boolean`` This flag indicates that the output is activate on the tabpanel 
+     *   when you add the output if the output config container is a tabpanel
+     */
+    
+    /** api: config[outputAction]
+     *  ``Number`` The ``actions`` array index of the action that should
+     *  trigger this tool's output. Only valid if ``actions`` is configured.
+     *  Leave this unconfigured if none of the ``actions`` should trigger this
+     *  tool's output.
+     */
+    
+    /** api: config[actionTarget]
+     *  ``Object`` or ``String`` or ``Array`` Where to place the tool's actions 
+     *  (e.g. buttons or menus)? 
+     *
+     *  In case of a string, this can be any string that references an 
+     *  ``Ext.Container`` property on the portal, or a unique id configured on a 
+     *  component.
+     *
+     *  In case of an object, the object has a "target" and an "index" property, 
+     *  so that the tool can be inserted at a specified index in the target. 
+     *               
+     *  actionTarget can also be an array of strings or objects, if the action is 
+     *  to be put in more than one place (e.g. a button and a context menu item).
+     *
+     *  To reference one of the toolbars of an ``Ext.Panel``, ".tbar", ".bbar" or 
+     *  ".fbar" has to be appended. The default is "map.tbar". The viewer's main 
+     *  MapPanel can always be accessed with "map" as actionTarget. Set to null if 
+     *  no actions should be created.
+     *
+     *  Some tools provide a context menu. To reference this context menu as
+     *  actionTarget for other tools, configure an id in the tool's
+     *  outputConfig, and use the id with ".contextMenu" appended. In the
+     *  snippet below, a layer tree is created, with a "Remove layer" action
+     *  as button on the tree's top toolbar, and as menu item in its context
+     *  menu:
+     *
+     *  .. code-block:: javascript
+     *
+     *     {
+     *         xtype: "gxp_layertree",
+     *         outputConfig: {
+     *             id: "tree",
+     *             tbar: []
+     *         }
+     *     }, {
+     *         xtype: "gxp_removelayer",
+     *         actionTarget: ["tree.tbar", "tree.contextMenu"]
+     *     }
+     *
+     *  If a tool has both actions and output, and you want to force it to
+     *  immediately output to a container, set actionTarget to null. If you
+     *  want to hide the actions, set actionTarget to false. In this case, you
+     *  should configure a defaultAction to make sure that an action is active.
+     */
+    actionTarget: "north.tbar",
+        
+    /** api: config[toggleGroup]
+     *  ``String`` If this tool should be radio-button style toggled with other
+     *  tools, this string is to identify the toggle group.
+     */
+    
+    /** api: config[defaultAction]
+     *  ``Number`` Optional index of an action that should be active by
+     *  default. Only works for actions that are a ``GeoExt.Action`` instance.
+     */
+    
+    /** api: config[outputTarget]
+     *  ``String`` Where to add the tool's output container? This can be any
+     *  string that references an ``Ext.Container`` property on the portal, or
+     *  "map" to access the viewer's main map. If not provided, a window will
+     *  be created.
+     */
+    outputTarget: "mainTabPanel",
+     
+    /** api: config[outputConfig]
+     *  ``Object`` Optional configuration for the output container. This may
+     *  be useful to override the xtype (e.g. "window" instead of "gx_popup"),
+     *  or to provide layout configurations when rendering to an
+     *  ``outputTarget``.
+     */
+
+    /** api: config[controlOptions]
+     *  ``Object`` If this tool is associated with an ``OpenLayers.Control``
+     *  then this is an optional object to pass to the constructor of the
+     *  associated ``OpenLayers.Control``.
+     */
+    
+    /** private: property[target]
+     *  ``Object``
+     *  The :class:`mxp.widgets.SNManagerViewport` that this plugin is plugged into.
+     */
+     
+    /** private: property[actions]
+     *  ``Array`` The actions this tool has added to viewer components.
+     */
+    
+    /** private: property[output]
+     *  ``Array`` output added by this container
+     */
+    output: null,
+
+
+    /** api: config[notDuplicateOutputs]
+     *  ``Boolean`` Flag to indicate that this tool couldn't duplicate in the tab panel.
+     */
+     notDuplicateOutputs: true,
+     
+    /** private: method[constructor]
+     */
+    constructor: function(config) {
+        this.initialConfig = config || {};
+        this.active = false;
+        Ext.apply(this, config);
+        if (!this.id) {
+            this.id = Ext.id();
+        }
+        this.output = [];
+        
+        this.addEvents(
+            /** api: event[activate]
+             *  Fired when the tool is activated.
+             *
+             *  Listener arguments:
+             *  * tool - :class:`mxp.plugins.Tool` the activated tool
+             */
+            "activate",
+
+            /** api: event[deactivate]
+             *  Fired when the tool is deactivated.
+             *
+             *  Listener arguments:
+             *  * tool - :class:`mxp.plugins.Tool` the deactivated tool
+             */
+            "deactivate",
+
+            /** api: event[actionsadded]
+             *  Fired when the addActions method is completed.
+             *
+             *  Listener arguments:
+             *  * tool - :class:`mxp.plugins.Tool` the tool
+             */
+            "actionsadded",
+
+            /** api: event[outputadded]
+             *  Fired when an output is added
+             *
+             *  Listener arguments:
+             *  * output - the output added
+             */
+            "outputadded"
+        );
+        
+        mxp.plugins.Tool.superclass.constructor.apply(this, arguments);
+    },
+    
+    /** private: method[init]
+     *  :arg target: ``Object`` The object initializing this plugin.
+     */
+    init: function(target) {
+        target.tools[this.id] = this;
+        this.target = target;
+        this.autoActivate && this.activate();
+        this.target.on("portalready", this.addActions, this);
+    },
+    
+    /** api: method[activate]
+     *  :returns: ``Boolean`` true when this tool was activated
+     *
+     *  Activates this tool.
+     */
+    activate: function() {
+        if (this.active === false) {
+            this.active = true;
+            this.fireEvent("activate", this);
+            return true;
+        }
+    },
+    
+    /** api: method[deactivate]
+     *  :returns: ``Boolean`` true when this tool was deactivated
+     *
+     *  Deactivates this tool.
+     */
+    deactivate: function() {
+        if (this.active === true) {
+            this.active = false;
+            this.fireEvent("deactivate", this);
+            return true;
+        }
+    },
+    
+    /** api: method[addActions]
+     *  :arg actions: ``Array`` Optional actions to add. If not provided,
+     *      this.actions will be added.
+     *  :returns: ``Array`` The actions added.
+     */
+    addActions: function(actions) {
+        actions = actions || this.actions;
+		
+        if (!actions || this.actionTarget === null) {
+            // add output immediately if we have no actions to trigger it
+            this.addOutput();
+            return;
+        }
+        
+        var actionTargets = this.actionTarget instanceof Array ?
+            this.actionTarget : [this.actionTarget];
+        var a = actions instanceof Array ? actions : [actions];
+        var action, actionTarget, i, j, jj, parts, ref, item, ct, meth, index = null;
+        for (i=actionTargets.length-1; i>=0; --i) {
+            actionTarget = actionTargets[i];
+            if (actionTarget) {
+                if (actionTarget instanceof Object) {
+                    index = actionTarget.index;
+                    actionTarget = actionTarget.target;
+                }
+                parts = actionTarget.split(".");
+                ref = parts[0];
+                item = parts.length > 1 && parts[1];
+                ct = Ext.getCmp(this.target.id + "_" + ref) || this.target.portal[ref];
+                if (item) {
+                    meth = {
+                        "tbar": "getTopToolbar",
+                        "bbar": "getBottomToolbar",
+                        "fbar": "getFooterToolbar"
+                    }[item];
+                    if (meth) {
+                        ct = ct[meth]();
+                    } else {
+                        ct = ct[item];
+                    }
+                }
+            }
+            for (j=0, jj=a.length; j<jj; ++j) {
+                if (!(a[j] instanceof Ext.Action || a[j] instanceof Ext.Component)) {
+                    if (typeof a[j] != "string") {
+                        if (j == this.defaultAction) {
+                            a[j].pressed = true;
+                        }
+                        a[j] = new Ext.Action(a[j]);
+                    }
+                }
+                action = a[j];
+                if (j == this.defaultAction && action instanceof GeoExt.Action) {
+                    action.isDisabled() ?
+                        action.activateOnEnable = true :
+                        action.control.activate();
+                }
+                if (ct) {
+                    if (ct instanceof Ext.menu.Menu) {
+                        action = Ext.apply(new Ext.menu.Item(action),
+                            {text: action.initialConfig.menuText}
+                        );
+                    } else if (!(ct instanceof Ext.Toolbar)) {
+                        // only Ext.menu.Menu and Ext.Toolbar containers
+                        // support the Action interface. So if our container is
+                        // something else, we create a button with the action.
+                        action = new Ext.Button(action);
+                    }
+                    var addedAction = (index === null) ? ct.add(action) : ct.insert(index, action);
+                    action = action instanceof Ext.Button ? action : addedAction;
+                    if (index !== null) {
+                        index += 1;
+                    }
+                    if (this.outputAction != null && j == this.outputAction) {
+                        var cmp;
+                        action.on("click", function() {
+                            if (cmp) {
+                                this.outputTarget ?
+                                    cmp.show() : cmp.ownerCt.ownerCt.show();
+                            } else {
+                                cmp = this.addOutput();
+                            }
+                        }, this);
+                    }
+                }
+            }
+            // call ct.show() in case the container was previously hidden (e.g.
+            // the mapPanel's bbar or tbar which are initially hidden)
+            if (ct) {
+                ct.isVisible() ?
+                    ct.doLayout() : ct instanceof Ext.menu.Menu || ct.show();
+            }
+        }
+        this.actions = a;
+        this.fireEvent("actionsadded", this);
+        return this.actions;
+    },
+    
+    /** api: method[addOutput]
+     *  :arg config: ``Object`` configuration for the ``Ext.Component`` to be
+     *      added to the ``outputTarget``. Properties of this configuration
+     *      will be overridden by the applications ``outputConfig`` for the
+     *      tool instance.
+     *  :return: ``Ext.Component`` The component added to the ``outputTarget``. 
+     *
+     *  Adds output to the tool's ``outputTarget``. This method is meant to be
+     *  called and/or overridden by subclasses.
+     */
+    addOutput: function(config) {
+
+        if (!config && !this.outputConfig) {
+            // nothing to do here for tools that don't have any output
+            return;
+        }
+
+        if(this.notDuplicateOutputs
+            && this.output.length > 0
+            && this.outputTarget){
+            for(var i = 0; i < this.output.length; i++){
+                if(this.output[i].ownerCt
+                    && this.output[i].ownerCt.xtype 
+                    && this.output[i].ownerCt.xtype == "tabpanel"
+                    && !this.output[i].isDestroyed){
+                    var outputConfig = config || this.outputConfig;
+                    // Not duplicate tabs
+                    for(var index = 0; index < this.output[i].ownerCt.items.items.length; index++){
+                        var item = this.output[i].ownerCt.items.items[index];
+                        var isCurrentItem = true;
+                        for (var key in outputConfig){
+                            if(outputConfig[key]){
+                                isCurrentItem = isCurrentItem && (outputConfig[key] == item.initialConfig[key]);
+                            }
+                        }
+                        if(isCurrentItem){
+                            this.output[i].ownerCt.setActiveTab(index);
+                            return;
+                        }
+                    }
+                }
+            }
+        }
+
+        config = config || {};
+        var ref = this.outputTarget;
+        var container;
+        if (ref) {
+            container = Ext.getCmp(ref) || this.target.portal[ref];
+            Ext.apply(config, this.outputConfig);
+        } else {
+            var outputConfig = this.outputConfig || {};
+            container = new Ext.Window(Ext.apply({
+                hideBorders: true,
+                shadow: false,
+                closeAction: "hide",
+                autoHeight: !outputConfig.height,
+                layout: outputConfig.height ? "fit" : undefined,
+                defaults: {
+                    autoHeight: !outputConfig.height
+                },
+                items: [outputConfig]
+            })).show().items.get(0);
+        }
+        var component = container.add(config);            
+        if (component instanceof Ext.Window) {
+            component.show();
+        } else {
+            try{
+                if(container.xtype && container.xtype == "tabpanel"){
+                    var index = container.items.length - 1;
+                    if(this.setActiveOnOutput){
+                        container.setActiveTab(index);
+                    }
+                    // save ownerCt and index in the output
+                    component.ownerCt = container;
+                    component.tabIndex = index;
+                }
+                container.doLayout();
+            }catch (e){
+                // FIXME: for tab do layout it fails
+            }
+        }
+        this.output.push(component);
+        this.fireEvent("outputadded", component);
+        return component;
+    },
+    
+    /** api: method[removeOutput]
+     *  Removes all output created by this tool
+     */
+    removeOutput: function() {
+        var cmp;
+        for (var i=this.output.length-1; i>=0; --i) {
+            cmp = this.output[i];
+            if (!this.outputTarget) {
+                cmp.findParentBy(function(p) {
+                    return p instanceof Ext.Window;
+                }).close();
+            } else {
+                if (cmp.ownerCt) {
+                    cmp.ownerCt.remove(cmp);
+                    if (cmp.ownerCt instanceof Ext.Window) {
+                        cmp.ownerCt[cmp.ownerCt.closeAction]();
+                    }
+                } else {
+                    cmp.remove();
+                }
+            }
+        }
+        this.output = [];
+    },
+    
+    /** api: method[removeActions]
+     *  Removes all actions created by this tool
+     */
+    removeActions: function() {
+        if(this.actions){
+            var cmp;
+            var parent;
+            for (var i=this.actions.length-1; i>=0; --i) {
+                cmp = this.actions[i];
+                if (!this.actionTarget) {
+                    cmp.findParentBy(function(p) {
+                        return p instanceof Ext.Window;
+                    }).close();
+                } else {
+                    if (cmp.ownerCt) {
+                        parent = cmp.ownerCt;
+                        cmp.ownerCt.remove(cmp);
+                    }else if (parent){
+                        parent.remove(cmp);
+                    }else if(cmp.remove){
+                        cmp.remove();
+                    }
+                }
+            }
+            this.actions = [];
+        }
+    },
+    
+    /** api: method[remove]
+     *  Removes all actions and outputs created by this tool
+     */
+    remove: function() {
+        this.removeOutput();
+        this.removeActions();
+        this.target.removeListener("portalready", this.addActions, this);
+    }
+    
+});
+
+Ext.preg(mxp.plugins.Tool.prototype.ptype, mxp.plugins.Tool);

--- a/mapcomposer/app/static/externals/mapmanager/src/mxp/plugins/UserManager.js
+++ b/mapcomposer/app/static/externals/mapmanager/src/mxp/plugins/UserManager.js
@@ -1,0 +1,131 @@
+/*
+ *  Copyright (C) 2007 - 2014 GeoSolutions S.A.S.
+ *  http://www.geo-solutions.it
+ *
+ *  GPLv3 + Classpath exception
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+ 
+/** api: (define)
+ *  module = mxp.plugins
+ *  class = UserManager
+ */
+Ext.ns("mxp.plugins");
+
+/** api: constructor
+ *  .. class:: UserManager(config)
+ *
+ *    Open a user manager panel
+ */
+mxp.plugins.UserManager = Ext.extend(mxp.plugins.Tool, {
+    
+    /** api: ptype = mxp_usermanager */
+    ptype: "mxp_usermanager",
+
+    buttonText: "User manager",
+    tooltipText: "Open user manager",
+
+    setActiveOnOutput: true,
+
+    loginManager: null, 
+
+    // default configuration for the output
+    outputConfig: {
+        closable: true,
+        closeAction: 'close',
+        autoWidth: true,
+        viewConfig: {
+            forceFit: true
+        }       
+    },
+
+    /** api: method[addActions]
+     */
+    addActions: function() {
+        
+        var thisButton = new Ext.Button({
+            text: this.buttonText,
+            tooltip: this.tooltipText,
+            handler: function() { 
+                // add output if not present
+                this.addOutput();
+            },
+            scope: this
+        });
+
+        var actions = [thisButton];
+
+        return mxp.plugins.UserManager.superclass.addActions.apply(this, [actions]);
+    },
+    
+    /** api: method[addOutput]
+     *  :arg config: ``Object`` configuration for the ``Ext.Component`` to be
+     *      added to the ``outputTarget``. Properties of this configuration
+     *      will be overridden by the applications ``outputConfig`` for the
+     *      tool instance.
+     *  :return: ``Ext.Component`` The component added to the ``outputTarget``. 
+     *
+     *  Adds output to the tool's ``outputTarget``. This method is meant to be
+     *  called and/or overridden by subclasses.
+     */
+    addOutput: function(config) {
+
+        var login = this.target.login ? this.target.login: 
+                this.loginManager && this.target.currentTools[this.loginManager] 
+                ? this.target.currentTools[this.loginManager] : null;
+
+        // create a user manager panel
+    	Ext.apply(this.outputConfig, {
+            xtype: "msm_usermanager",
+            iconCls: "open_usermanager",
+            title: this.buttonText,
+            id: this.target.userMamanagerId,
+            ASSET: this.target.config.ASSET,
+            auth: login.login.getToken(),
+            login: login.login,
+            searchUrl: this.target.geoSearchUsersUrl,
+            url: this.target.geoBaseUsersUrl,
+            geoStoreBase: this.target.config.geoStoreBase,
+            renderMapToTab: this.outputTarget
+    	});
+
+        // In user information the output is generated in the component and we can't check the item.initialConfig.
+        if(this.output.length > 0
+            && this.outputTarget){
+            for(var i = 0; i < this.output.length; i++){
+                if(this.output[i].ownerCt
+                    && this.output[i].ownerCt.xtype 
+                    && this.output[i].ownerCt.xtype == "tabpanel"
+                    && !this.output[i].isDestroyed){
+                    var outputConfig = config || this.outputConfig;
+                    // Not duplicate tabs
+                    for(var index = 0; index < this.output[i].ownerCt.items.items.length; index++){
+                        var item = this.output[i].ownerCt.items.items[index];
+                        // only check iconCls
+                        var isCurrentItem = "open_usermanager" == item.initialConfig["iconCls"];
+                        if(isCurrentItem){
+                            this.output[i].ownerCt.setActiveTab(index);
+                            return;
+                        }
+                    } 
+                }
+            }
+        }
+
+        return mxp.plugins.UserManager.superclass.addOutput.apply(this, arguments);
+    }
+});
+
+Ext.preg(mxp.plugins.UserManager.prototype.ptype, mxp.plugins.UserManager);

--- a/mapcomposer/app/static/externals/mapmanager/src/mxp/widgets/ManagerViewport.js
+++ b/mapcomposer/app/static/externals/mapmanager/src/mxp/widgets/ManagerViewport.js
@@ -1,0 +1,366 @@
+/*
+ *  Copyright (C) 2007 - 2014 GeoSolutions S.A.S.
+ *  http://www.geo-solutions.it
+ *
+ *  GPLv3 + Classpath exception
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/** api: (define)
+ *  module = mxp.widgets
+ *  class = ManagerViewport
+ *  base_link = `Ext.Viewport <http://extjs.com/deploy/dev/docs/?class=Ext.Viewport>`_
+ */
+Ext.ns('mxp.widgets');
+
+/**
+ * Class: ManagerViewport
+ * Viewport for the Manager application
+ * 
+ * Inherits from:
+ *  - <Ext.Viewport>
+ *
+ */
+mxp.widgets.ManagerViewport = Ext.extend(Ext.Viewport, {
+
+    /** api: xtype = mxp_viewport */
+    xtype: "mxp_viewport",
+
+    /**
+     * Property: config
+     * {object} object for configuring the component. See <config.js>
+     *
+     */
+    config : null,
+    /**
+     * Property: layout
+     * {string} sets the type of layout
+     * 
+     */ 
+    layout:'fit',
+
+    /** api: config[tools]
+     *  ``Array`` Custom tools to include by default
+     */
+
+    /** api: config[tools]
+     *  ``Array`` Custom tools to include in a logged user. TODO: Remove when load logged tools.
+     */
+
+    /** api: config[currentTools]
+     *  ``Array`` Current active tools.
+     */
+    currentTools: {},
+
+    /** private: config[logged]
+     *  ``Boolean`` Login status. By default false.
+     */
+    logged: false, 
+
+    /** private: config[pluggableByUserGroupConfig]
+     *  ``Boolean`` Try to get ADMINCONFIG from geostore when an user is logged. By default false.
+     */
+    pluggableByUserGroupConfig: false,
+    
+    initComponent : function() {
+
+        // save initial config
+        this.initialConfig = {};
+        Ext.apply(this.initialConfig, this);
+        Ext.apply(this.initialConfig, this.config);
+
+        // copy pluggableByUserGroupConfig config
+        this.pluggableByUserGroupConfig = this.initialConfig.pluggableByUserGroupConfig;
+
+        // /////////////////////////
+        // Init useful URLs
+        // /////////////////////////
+        var config = this.config;
+        var geoStoreBase = config.geoStoreBase;
+        this.murl = config.composerUrl;
+        this.socialUrl = config.socialUrl;
+        
+        this.geoBaseUsersUrl= geoStoreBase + 'users';
+        this.geoBaseMapsUrl = geoStoreBase + 'resources';
+        this.geoSearchUrl = geoStoreBase + 'extjs/search/category/MAP/';
+        // this.geoSearchUrl = geoStoreBase + 'extjs/search/';
+        this.geoSearchUsersUrl = geoStoreBase + 'extjs/search/users';
+        this.geoSearchCategoriesUrl = geoStoreBase + 'extjs/search/category';
+
+        var mergedItems = [];
+
+        // this component is the tool bar at top
+        var north = {
+            region: "north",
+            layout: "fit",
+            id: this.id + "_north",
+            border: false,
+            tbar: ["-", "->", "-"],
+            items: this.items
+        };
+
+        mergedItems.push(north);
+
+        this.items = mergedItems;
+        
+        mxp.widgets.ManagerViewport.superclass.initComponent.call(this, arguments);
+
+        this.fireEvent("portalready");
+
+        // load config if present
+        this.reloadConfig();
+    },
+    
+    initTools: function() {
+        this.loadTools(this.initialConfig.tools);
+    },
+
+    cleanTools: function(){
+        for(var id in this.currentTools){
+            this.currentTools[id].remove();
+        }
+        var mainPanel = Ext.getCmp("mainTabPanel");
+        try{
+            mainPanel.removeAll();
+        }catch (e){
+            // FIXME: some error here
+        }
+        this.currentTools = {};
+    },
+    
+    loadTools: function(tools) {
+        this.tools = {};
+        if (tools && tools.length > 0) {
+            var tool;
+            for (var i=0, len=tools.length; i<len; i++) {
+                try {
+
+                    if(tools[i].needsAuthorization && !this.auth)
+                        continue;
+                    
+                    tool = Ext.ComponentMgr.createPlugin(
+                        tools[i], this.defaultToolType
+                    );
+
+                } catch (err) {
+                    throw new Error("Could not create tool plugin with ptype: " + this.initialConfig.tools[i].ptype);
+                }
+                tool.init(this);
+                this.currentTools[tool.pluginId ? tool.pluginId : tool.id] = tool;
+            }
+        }
+    },
+
+    /** private: method[reloadConfig]
+     *  Load existing configs available for the user logged/GUEST
+     */
+    reloadConfig: function(){
+        if(this.pluggableByUserGroupConfig){
+            this.adminConfigStore = new Ext.data.JsonStore({
+                root: 'results',
+                autoLoad: false,
+                totalProperty: 'totalCount',
+                successProperty: 'success',
+                idProperty: 'id',
+                fields: [
+                    'id',
+                    'name'
+                ],
+                proxy: new Ext.data.HttpProxy({
+                    url: this.config.geoStoreBase + 'extjs/search/category/ADMINCONFIG',
+                    restful: true,
+                    method : 'GET',
+                    disableCaching: true,
+                    failure: function (response) {
+                        Ext.Msg.show({
+                           title: "Error",
+                           msg: response.statusText + "(status " + response.status + "):  " + response.responseText,
+                           buttons: Ext.Msg.OK,
+                           icon: Ext.MessageBox.ERROR
+                        });                                
+                    }
+                }),
+                listeners:{
+                    load: this.adminConfigLoad,
+                    scope: this
+                }
+            });
+            this.adminConfigStore.proxy.getConnection().defaultHeaders= {
+                'Accept': 'application/json', 
+                'Authorization' : this.auth
+            };
+            this.adminConfigStore.load();
+        }else{
+            // Load default config
+            this.adminConfigLoad(null);
+        }
+    },
+
+    /** private: method[adminConfigLoad]
+     *  Load the admin config from the configuration present on the store
+     */
+    adminConfigLoad: function(store){
+        if(store && store.getCount && store.getCount() > 0){
+            var pendingConfig = store.getCount();
+            // TODO: use config to extent this functionality
+            var config = {
+                tools: this.initialConfig.loggedTools
+            };
+            this.on("loadcustomconfig", function(customConfig){
+                pendingConfig--;
+                if(customConfig && customConfig instanceof Array){
+                    // now only add tools
+                    config["tools"] = this.addAll(customConfig, config["tools"]);
+                }else if(customConfig && customConfig instanceof Object){
+                    // in the future we can add different configs (removeTools, headers...?)
+                    for(var key in customConfig) {
+                        if(!config[key]){
+                            config[key] = customConfig[key];
+                        }else if(config[key] instanceof Array){
+                            config[key] = this.addAll(customConfig[key], config[key]);
+                        }else if(config[key] instanceof Object){
+                            Ext.apply(config[key], customConfig[key]);
+                        }else{
+                            config[key] = customConfig[key];
+                        }
+                    }   
+                }
+                // TODO: use config to extent this functionality
+                this.applyUserConfig(pendingConfig, config.tools);
+            });
+            store.each(function(item){
+                this.loadData(null, item.get("id"), "loadcustomconfig");
+            }, this);
+        }else{
+            // load default logged tools
+            this.applyUserConfig(0, this.logged ? this.initialConfig.loggedTools : this.initialConfig.tools);
+        }
+    },
+
+    /** private: method[loadData]
+     *  Load a configuration from an url
+     */
+    loadData: function (url, dataId, eventListener){
+        var url = (url ? url: this.initialConfig.geoStoreBase + "data/" + dataId);
+        if(url.indexOf("/") != 0){
+            url = this.initialConfig.proxy + url;
+        }
+        Ext.Ajax.request({
+            method: 'GET',
+            scope: this,
+            url: url,
+            success: function(response, opts){
+                try{
+                    var loadedConfig = Ext.util.JSON.decode(response.responseText);
+                    this.fireEvent(eventListener, loadedConfig);
+                }catch(e){
+                    console.error("Error getting config");
+                    this.fireEvent(eventListener, {});
+                }
+            },
+            failure:  function(response, opts){
+                console.error("Error getting config");
+                    this.fireEvent(eventListener, {});
+            }
+        });
+    },
+
+    /** private: method[addAll]
+     */
+    addAll: function(toAdd, target){
+        var componentsNotPresent = [];
+        if(toAdd instanceof Array){
+            for(var i = 0; i < toAdd.length; i++){
+                if(!this.isAlreadyPresent(toAdd[i], target)){
+                    componentsNotPresent.push(toAdd[i]);
+                }
+            }   
+        }else if(toAdd instanceof Object){
+            if(!this.isAlreadyPresent(toAdd, target)){
+                componentsNotPresent.push(toAdd);
+            }
+        }
+        return target.concat(componentsNotPresent);
+    },
+
+    /** private: method[isAlreadyPresent]
+     */
+    isAlreadyPresent: function(element, elements){
+        //TODO: checkall, now only check ptype
+        var isAlreadyPresent = false;
+        if(elements && element){
+            for(var i = 0; i < elements.length; i++){
+                if(elements[i].ptype == element.ptype){
+                    isAlreadyPresent = true;   
+                    break;
+                }
+            }
+        }
+        return isAlreadyPresent;
+    },
+
+    /** private: method[applyUserConfig]
+     *  Apply tools available for logged user
+     */
+    applyUserConfig: function(pendingConfig, tools){
+        if(pendingConfig == 0 && tools && tools.length > 0){
+            this.cleanTools();
+            this.loadTools(tools);
+            this.fireEvent("portalready");   
+        }
+    },
+
+    /** private: method[onLogin]
+     *  Listener with actions to be executed when an user makes login.
+     */
+    onLogin: function(user, auth){
+        if(!this.logged && user){
+            this.cleanTools();
+            this.auth = auth ? auth: this.auth;
+            this.logged = true;
+
+            this.defaultHeaders = {
+                'Accept': 'application/json', 
+                'Authorization' : this.auth
+            };
+
+            // reload config
+            this.reloadConfig();
+        }
+    },
+
+    /** private: method[onLogout]
+     *  Listener with actions to be executed when an user makes logout.
+     */
+    onLogout: function(){
+        if(this.logged){
+            this.auth = null;
+
+            // Remove headers
+            this.defaultHeaders = {
+                'Accept': 'application/json',
+                'Authorization' : "",
+            };
+
+            this.cleanTools();
+            this.initTools();
+            this.logged = false;
+            this.fireEvent("portalready");   
+        }
+    }
+});
+
+/** api: xtype = mxp_viewport */
+Ext.reg(mxp.widgets.ManagerViewport.prototype.xtype, mxp.widgets.ManagerViewport);

--- a/mapcomposer/app/templates/composer.html
+++ b/mapcomposer/app/templates/composer.html
@@ -124,10 +124,12 @@
 									} 
 									break;
 					case "auth" : 
-									if(param[1] == 'true') 
-										authorization = true; 
-									else 
-										authorization = false; 
+									authorization = param[1]; 
+									if(param.length > 2){
+										for(var i = 2; i < param.length; i++){
+											authorization += "=";
+										}
+									}
 									break;
 					case "fullScreen" : 
 									if(param[1] == 'true') 
@@ -400,7 +402,7 @@
                 georeferences: georeferences_data,
                 map: serverConfig.map,
 				customTools: serverConfig.customTools
-            }, mapIdentifier, authorization, fullScreen, templateId);   
+            }, mapIdentifier, authorization && authorization == "false" ? null: authorization, fullScreen, templateId);   
             
             app.on({
                 'portalready' : function() {              	
@@ -497,94 +499,23 @@
 			};
 	    };
 
-	    Ext.Ajax.request({
-			  url: customConfigName ? "config/" + customConfigName + ".js"  : "config/mapStoreConfig.js",
-			  method: 'GET',
-			  success: function(response, opts){          
-				  
-				  try{
-					  serverConfig = Ext.util.JSON.decode(response.responseText);
-					  proxy = mapStoreDebug === true ? "/proxy/?url=" : serverConfig.proxy;
-				  }catch(e){
-					  Ext.Msg.show({
-							title: "Startup",
-							msg: "An error occurred while parsing the external configuration: " + response.status,
-							buttons: Ext.Msg.OK,
-							icon: Ext.MessageBox.ERROR
-					  });
-				  }
+	    // geostore base
+	    if(!serverConfig){
+	    	serverConfig = {};
+	    }
+		serverConfig.geoStoreBaseURL = serverConfig.geoStoreBase || ('http://' + window.location.host + '/geostore/rest/');
 
-				  // load template config
-				  if(templateId){
-				  		// include proxy and/or geoStoreBase
-				  		var templateLoadUrl = (serverConfig && serverConfig.geoStoreBase ? serverConfig.geoStoreBase : ('http://' + window.location.host + '/geostore/rest/')) + "data/" + templateId;
-				  		if(proxy){
-				  			templateLoadUrl = proxy + templateLoadUrl;
-				  		}
-						Ext.Ajax.request({
-							url: templateLoadUrl,
-							method: 'GET',
-							success: function(response, opts){          
-							  
-							  var templateConfig;
-							  try{
-								  templateConfig = Ext.util.JSON.decode(response.responseText);
-							  }catch(e){
-								  Ext.Msg.show({
-										title: "Startup",
-										msg: "An error occurred while parsing the template configuration: " + response.status,
-										buttons: Ext.Msg.OK,
-										icon: Ext.MessageBox.ERROR
-								  });
-							  }
-							  
-							  if(serverConfig){
-								  //apply the local default configuration if not present.
-								  serverConfig = Ext.applyIf(serverConfig,localConfig);
-								  proxy = mapStoreDebug === true ? "/proxy/?url=" : serverConfig.proxy;
+		// use GeoExplorerLoader to load configuration files
+		var loader = new GeoExplorerLoader(serverConfig, customConfigName, mapStoreDebug, mapIdentifier, authorization, fullScreen, templateId);
+		loader.on("configfinished", function (config){
+              //apply the loaded configuration.
+              serverConfig = Ext.applyIf(serverConfig, config);
+              proxy = mapStoreDebug === true ? "/proxy/?url=" : serverConfig.proxy;
 
-								  // apply the template config
-								  if(templateConfig){
-								  	Ext.apply(serverConfig, templateConfig);
-								  }
+              //ready to create GeoExplorer
+              Ext.onReady(onReady);
+		});
 
-								  // ///////////////////////////////////////////////  
-								  // Run the application when browser is ready
-								  // ///////////////////////////////////////////////
-								  Ext.onReady(onReady);
-							  }
-							},
-							failure:  function(response, opts){
-							  Ext.Msg.show({
-									title: "Startup",
-									msg: "An error occurred while getting the template configuration: " + response.status,
-									buttons: Ext.Msg.OK,
-									icon: Ext.MessageBox.ERROR
-							  });
-							}
-						});
-				  }else{
-					  if(serverConfig){
-						  //apply the local default configuration if not present.
-						  serverConfig = Ext.applyIf(serverConfig,localConfig);
-						  proxy = mapStoreDebug === true ? "/proxy/?url=" : serverConfig.proxy; 
-
-						  // ///////////////////////////////////////////////  
-						  // Run the application when browser is ready
-						  // ///////////////////////////////////////////////
-						  Ext.onReady(onReady);
-					  }
-				  }
-			  },
-			  failure:  function(response, opts){
-				  Ext.Msg.show({
-						title: "Startup",
-						msg: "An error occurred while getting the external configuration: " + response.status,
-						buttons: Ext.Msg.OK,
-						icon: Ext.MessageBox.ERROR
-				  });
-		      }
-	    });        
     </script>
 
 	<div style="visibility:hidden"><canvas id="printcanvas" /></div>

--- a/mapcomposer/app/templates/geonetwork.html
+++ b/mapcomposer/app/templates/geonetwork.html
@@ -94,7 +94,7 @@
     <script>
         
         var app;        
-        var modified = false; var mapIdentifier = -1; var authorization = false; var fullScreen = false;
+        var modified = false; var mapIdentifier = -1; var authorization = false; var fullScreen = false; var templateId = "defaultTemplate";
 		
 		// /////////////////////////////////////////////////////
 		// Extra parameters to manage geonetwork integration
@@ -151,6 +151,13 @@
 					case "config":	
 									customConfigName = param[1];
 									break;
+                    case "configId": 
+                                    try{
+                                        templateId = parseInt(param[1]);
+                                    }catch(e){
+                                        templateId = -1;
+                                    } 
+                                    break;
 					default :       
 									//mapIdentifier = -1;
 									//authorization = false;
@@ -307,7 +314,73 @@
                 handler: function(btn){
                     window.open('http://www.geo-solutions.it/about/contacts/', '_blank');
                 }
-            });    
+            }); 
+            
+            var header = serverConfig.header;
+            var footer = serverConfig.footer;
+            
+            var viewport = {
+                    id: 'appVieport',
+                    layout: 'fit',
+                    border: false
+            };
+
+            // in header and footer, we need numbers, not strings
+            var parseKnowIntegers = function(section){
+                var knownInteger = {'height':true, 'maxHeight': true, 'minWidth':true};
+                for(var key in knownInteger){
+                    if(section[key]){
+                        try{
+                            section[key] = parseInt(section[key]);  
+                        }catch (e){
+                            // unknown parameter value
+                        }
+                    }   
+                }
+                return section;
+            }
+            
+            if(header || footer){
+                var north = {
+                    header: false,
+                    region: 'north',
+                    id: 'msheader'
+                };
+            
+                if(header){
+                    north = Ext.applyIf(north, (header.container ? parseKnowIntegers(header.container) : {}));
+                    north.html = (header.css || '') + (header.html || '');
+                }
+                
+                var south = {
+                    header: false,
+                    region: 'south',
+                    id: 'msfooter'
+                };
+                
+                if(footer){
+                    south = Ext.applyIf(south, (footer.container ? parseKnowIntegers(footer.container) : {}));
+                    south.html = (footer.css || '') + (footer.html || '');
+                }
+                
+                viewport.items = [{
+                    region: 'center',
+                    layout: 'border',
+                    border: false,
+                    header: false, 
+                    items: [north, appTabs, south]
+                }];
+            }else{
+                viewport.items = [{
+                    region: 'center',
+                    layout: 'border',
+                    border: false,
+                    header: false,                    
+                    items: [appTabs]
+                }]
+            }           
+            
+            var appViewport = new Ext.Viewport(viewport);   
 			
 			// ///////////////////////////////////
 			// Header definition
@@ -323,36 +396,36 @@
 					'			</div>'
 			];*/
 			
-			var headerContent = serverConfig.header || '';
+			// var headerContent = serverConfig.header || '';
 			
-			var footerContent = serverConfig.footer || '';
+			// var footerContent = serverConfig.footer || '';
 			
-            var appViewport = new Ext.Viewport({
-                id: 'appVieport',
-                layout:'fit',
-                border:false,
-                items: [{
-                    region : 'center',
-                    layout : 'border',
-                    border : false,
-                    header : false,                    
-                    items : [{
-                      border: false,
-                      header: false,
-                      html:  headerContent,
-                      region: 'north',
-                      collapsible: true,
-                      collapseMode:  'mini',
-                      hideCollapseTool: true,
-                      split: true,
-                      animCollapse : false,
-                      minHeight: 140,
-                      maxHeight: 140,
-                      height: 140,
-                      id : 'msheader'
-                    },appTabs]
-                }]
-            });
+   //          var appViewport = new Ext.Viewport({
+   //              id: 'appVieport',
+   //              layout:'fit',
+   //              border:false,
+   //              items: [{
+   //                  region : 'center',
+   //                  layout : 'border',
+   //                  border : false,
+   //                  header : false,                    
+   //                  items : [{
+   //                    border: false,
+   //                    header: false,
+   //                    html:  headerContent,
+   //                    region: 'north',
+   //                    collapsible: true,
+   //                    collapseMode:  'mini',
+   //                    hideCollapseTool: true,
+   //                    split: true,
+   //                    animCollapse : false,
+   //                    minHeight: 140,
+   //                    maxHeight: 140,
+   //                    height: 140,
+   //                    id : 'msheader'
+   //                  },appTabs]
+   //              }]
+   //          });
             
             // /////////////////////////////////////////////////////////////
             // Parsing WMS servers Sources for getCapabilities operation
@@ -415,7 +488,7 @@
                 georeferences: georeferences_data,
                 map: serverConfig.map,
 				customTools: serverConfig.customTools
-            }, mapIdentifier, authorization, fullScreen);   
+            }, mapIdentifier, authorization && authorization == "false" ? null: authorization, fullScreen, templateId);   
             
 			/*app.viewMetadata = function(url, uuid, title){
 				var tabPanel = Ext.getCmp(this.renderToTab);
@@ -540,42 +613,17 @@
 			};
 	    };
 
-	    Ext.Ajax.request({
-			  url: customConfigName ? "config/" + customConfigName + ".js"  : "config/geonetwork.js",
-			  method: 'GET',
-			  success: function(response, opts){          
-				  
-				  try{
-					  serverConfig = Ext.util.JSON.decode(response.responseText);
-				  }catch(e){
-					  Ext.Msg.show({
-							title: "Startup",
-							msg: "An error occurred while parsing the external configuration: " + response.status,
-							buttons: Ext.Msg.OK,
-							icon: Ext.MessageBox.ERROR
-					  });
-				  }
-				  
-				  if(serverConfig){
-					  //apply the local default configuration if not present.
-					  serverConfig = Ext.applyIf(serverConfig,localConfig);
-					  proxy = mapStoreDebug === true ? "/proxy/?url=" : serverConfig.proxy; 
-					  
-					  // ///////////////////////////////////////////////  
-					  // Run the application when browser is ready
-					  // ///////////////////////////////////////////////
-					  Ext.onReady(onReady);
-				  }
-			  },
-			  failure:  function(response, opts){
-				  Ext.Msg.show({
-						title: "Startup",
-						msg: "An error occurred while getting the external configuration: " + response.status,
-						buttons: Ext.Msg.OK,
-						icon: Ext.MessageBox.ERROR
-				  });
-		      }
-	    });        
+        // use GeoExplorerLoader to load configuration files
+        var loader = new GeoExplorerLoader(serverConfig, customConfigName ? customConfigName: "geonetwork", mapStoreDebug, mapIdentifier, authorization, fullScreen, templateId);
+        loader.on("configfinished", function (config){
+              //apply the loaded configuration.
+              serverConfig = Ext.applyIf(serverConfig || {}, config);
+              proxy = mapStoreDebug === true ? "/proxy/?url=" : serverConfig.proxy;
+
+              //ready to create GeoExplorer
+              Ext.onReady(onReady);
+        });
+
     </script>
 
 	<div style="visibility:hidden"><canvas id="printcanvas" /></div>

--- a/mapcomposer/app/templates/manager.html
+++ b/mapcomposer/app/templates/manager.html
@@ -122,60 +122,20 @@
             if (GeoExt.Lang) {
                     GeoExt.Lang.set(code);
             }
-            
-            var languageSelector = new Ext.form.ComboBox({
-                store: new Ext.data.ArrayStore({
-                    fields: ['code', 'name'],
-                    data :  langData
-                }),
-                displayField: 'name',
-                typeAhead: true,
-                mode: 'local',
-                forceSelection: true,
-                triggerAction: 'all',
-                emptyText: initialLanguageString,
-                selectOnFocus:false,
-                editable: false,
-                width: 100,
-                listeners: {
-                    beforeselect: function(cb, record, index){
-                       if(code == record.get('code')){
-                            return false;
-                       }
-                    },                    
-                    select: function(cb, record, index) {         
-                       var code = record.get('code');
-                    
-                       var query = location.search;        
-                       if(query && query.substr(0,1) === "?"){
-                            query = query.substring(1);
-                       }  
-                       
-                       var url = Ext.urlDecode(query);
 
-                       if(code){
-                           location.replace(
-                               location.pathname + '?locale=' + code);                                   
-                       }
-                    }
-                }
+            // Apply config for lang selector
+            Ext.apply(config,{
+                langData: langData,
+                initialLanguageString: initialLanguageString,
+                code: code
             });
-            
-            var msmPanel = new MSMPanel ({
-                xtype: 'panel',
-                id: 'mapManagerPanel',
-                config: config,
-                lang: code,
-                renderMapToTab: 'mainTabPanel',
-                langSelector: languageSelector,
-                adminPanelsTargetTab : 'mainTabPanel'
-            });
-            new Ext.Viewport({
+            new mxp.widgets.ManagerViewport({
                 layout:'fit',
+                config: config,
                 items:{
                     xtype: 'tabpanel',
                     id:'mainTabPanel',
-                    items:[msmPanel],
+                    items:[],
                     enableTabScroll : true,
                     activeTab:0
                     
@@ -217,7 +177,8 @@
 						serverConfig.socialUrl = 'http://' + window.location.host;
 					  }
                       
-					  proxy = mapStoreDebug === true ? "/proxy/?url=" : serverConfig.proxy; 
+					  proxy = mapStoreDebug === true ? "/proxy/?url=" : serverConfig.proxy;
+                      serverConfig.proxy = proxy;
 					  
                       OpenLayers.ProxyHost = this.proxy; // Explicit because this application doesn't include
 					  

--- a/mapcomposer/buildjs.cfg
+++ b/mapcomposer/buildjs.cfg
@@ -252,6 +252,7 @@ include =
 	plugins/About.js
     locale/en.js
     locale/fr.js
+    GeoExplorerLoader.js
 
 [ux.js]
 root = app/static/externals/ext
@@ -339,6 +340,13 @@ include =
     src/Ext.ux/ImagePicker.js
     src/Ext.ux/PluploadButton.js
     src/Ext.ux/ExtendedHtmlEditor.js
+    src/mxp/widgets/ManagerViewport.js
+    src/mxp/plugins/Tool.js
+    src/mxp/plugins/Login.js
+    src/mxp/plugins/MapManager.js
+    src/mxp/plugins/TemplateManager.js
+    src/mxp/plugins/UserManager.js
+    src/mxp/plugins/LanguageSelector.js
 	
 exclude = 
 	src/config.js

--- a/mapcomposer/release/geonetwork/config.js
+++ b/mapcomposer/release/geonetwork/config.js
@@ -5,6 +5,7 @@ var urls = [
     [(/^\/(index(.html)?)?/), require("./root/index").app],
     //[(/^\/(login)/), require("./root/login").app],
     //[(/^\/(maps(\/\d+)?)/), require("./root/maps").app],
+    [(/^\/(manager)/), require("./root/manager").app],
 	[(/^\/(geonetwork)/), require("./root/geonetwork").app],  // Enable this only for the GeoNetwork integration
     [(/^\/(composer)/), require("./root/composer").app],
     [(/^\/(viewer(.html)?)/), require("./root/viewer").app],

--- a/release/config/categories.xml
+++ b/release/config/categories.xml
@@ -6,4 +6,10 @@
     <Category>
         <name>TEMPLATE</name>
     </Category>
+    <Category>
+        <name>ADMINCONFIG</name>
+    </Category>
+    <Category>
+        <name>MAPSTORECONFIG</name>
+    </Category>
 </CategoryList>

--- a/release/config/geostore-datasource-ovr.properties
+++ b/release/config/geostore-datasource-ovr.properties
@@ -29,3 +29,7 @@ geostoreInitializer.userListInitFile=file:config/users.xml
 #geostoreInitializer.categoryListInitFile=classpath:sample_categories.xml
 ## Use this form to point to an absoluthe file path
 geostoreInitializer.categoryListInitFile=file:config/categories.xml
+
+
+## Use this form to point to an absoluthe file path
+geostoreInitializer.userGroupListInitFile=file:config/groups.xml

--- a/release/config/groups.xml
+++ b/release/config/groups.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<UserGroupList>
+	<UserGroup>
+		<groupName>allresources</groupName>
+		<restUsers />
+		<id />
+	</UserGroup>
+	<UserGroup>
+		<groupName>poweruser</groupName>
+		<restUsers>poweruser</restUsers>
+		<id />
+	</UserGroup>
+</UserGroupList>

--- a/release/config/users.xml
+++ b/release/config/users.xml
@@ -10,4 +10,9 @@
         <newPassword>user</newPassword>
         <role>USER</role>
     </User>
+    <User>
+        <name>poweruser</name>
+        <newPassword>poweruser</newPassword>
+        <role>USER</role>
+    </User>
 </InitUserList>


### PR DESCRIPTION
Squashed commit from `sn_manager` branch:
- Include new categories, users and groups on geostore init files.
- Now the manager UI is a pluggable extjs application like MapStore.
- MapStore changes
  - New load method (now it can load custom tools by user or group)
  - Default header and footer has been removed
  - Load custom tools if available
  - Create a map without template
- GN integration fixes
  - Use default template for the header
  - Add manager app.
