### PR TITLE
Some fixes on mapstore manager

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -180,7 +180,7 @@
         </copy>
         <!-- copy mapmanager css  -->
         <copy todir="${composerbuild}/${ant.project.name}/WEB-INF/app/static/externals/mapmanager/theme/css">
-            <fileset file="mapcomposer/app/static/externals/mapmanager/theme/css/"
+            <fileset dir="mapcomposer/app/static/externals/mapmanager/theme/css/"
             />
         </copy>
         <!-- copy mapmanager img  -->

--- a/mapcomposer/app/static/externals/mapmanager/src/mxp/widgets/ManagerViewport.js
+++ b/mapcomposer/app/static/externals/mapmanager/src/mxp/widgets/ManagerViewport.js
@@ -91,6 +91,7 @@ mxp.widgets.ManagerViewport = Ext.extend(Ext.Viewport, {
         var geoStoreBase = config.geoStoreBase;
         this.murl = config.composerUrl;
         this.socialUrl = config.socialUrl;
+        this.adminUrl = config.adminUrl;
         
         this.geoBaseUsersUrl= geoStoreBase + 'users';
         this.geoBaseMapsUrl = geoStoreBase + 'resources';


### PR DESCRIPTION
- Fixes manager release css. Now is a folder, not a file.
- Copy `adminUrl` on the Manager configuration.
