### PR TITLE
OpenSDI Pictures can be displayed in GetFeatureInfo popup

### DIFF
--- a/mapcomposer/app/static/config/common/localConfig.js
+++ b/mapcomposer/app/static/config/common/localConfig.js
@@ -1,7 +1,14 @@
 /** This file contains the common configuration options 
  *  that can be overridden by the serverConfig objects in templates */
 var localConfig = {
-   geoStoreBase: "",
+   geoStoreBase: "http://geocollect.geo-solutions.it/geostore/rest/",
    proxy:"/http_proxy/proxy/?url=",
-   defaultLanguage: "en"
+   loginDataStorage : sessionStorage,
+   defaultLanguage: "en",
+   proj4jsDefs: {
+	"EPSG:3003":"+proj=tmerc +lat_0=0 +lon_0=9 +k=0.9996 +x_0=1500000 +y_0=0 +ellps=intl +units=m +no_defs",
+	"EPSG:23032":"+proj=utm +zone=32 +ellps=intl +units=m +no_defs",
+	"EPSG:25832":"+proj=utm +zone=32 +ellps=GRS80 +units=m +no_defs",
+	"EPSG:26591":"+proj=tmerc +lat_0=0 +lon_0=-3.45233333333333 +k=0.9996 +x_0=1500000 +y_0=0 +ellps=intl +pm=rome +units=m +no_defs"
+	}
 };

--- a/mapcomposer/app/static/config/geocollect.js
+++ b/mapcomposer/app/static/config/geocollect.js
@@ -1,5 +1,4 @@
 {
-
    "scaleOverlayMode": "basic",
    "gsSources":{ 
 		"mapquest": {
@@ -16,6 +15,10 @@
 		}, 
 		"ol": { 
 			"ptype": "gxp_olsource" 
+		},
+		"geoserver": {
+			"url":"http://84.33.2.28/geoserver/wms",
+			"ptype":"gxp_wmssource"
 		}
 	},
 	"loadingPanel": {
@@ -77,35 +80,20 @@
 				"args": [
 					"None", {"visibility": false}
 				]
+			},{
+				"source": "geoserver",
+				"infoFormat": "application/vnd.ogc.gml",
+				"name": "it.geosolutions:latest_rilievi",
+				"title": "Rilevamenti Effettuati",
+				"visibility": true,
+				"opacity": 1,
+				"selected": false,
+				"format": "image/png",
+				"styles": "rilievi",
+				"transparent": true
 			}
 		]
 	},
-    "customPanels":[ {
-            "xtype": "panel",
-            "title": "Features List",
-            "border": false,
-            "id": "south",
-            "region": "south",
-            "layout": "fit",
-            "split":true,
-            "height": 330,
-            "collapsed": true,
-            "collapsible": true,
-            "header": true
-        },{
-          "xtype": "panel",
-          "title": "Query Panel",         
-          "border": false,
-          "id": "east",
-          "width": 400,
-          "height": 500,
-          "region": "east",
-          "layout": "fit",
-          "collapsed": false,
-          "collapsible": true,
-          "header": true
-      }
-	],	
 	"scaleOverlayUnits":{
         "bottomOutUnits":"mi",    
         "bottomInUnits":"ft",    
@@ -120,79 +108,13 @@
 			"showDirectURL": true
 		}, {
 			"ptype": "gxp_categoryinitializer",
-            		"silentErrors": true,
+            "silentErrors": true,
 			"neededCategories": ["MAPSTORECONFIG", "GEOCOLLECT", "MAP"]
 		}, {
 		   "ptype": "gxp_mouseposition",
 		   "displayProjectionCode":"EPSG:4326",
 		   "customCss": "font-weight: bold; text-shadow: 1px 0px 0px #FAFAFA, 1px 1px 0px #FAFAFA, 0px 1px 0px #FAFAFA,-1px 1px 0px #FAFAFA, -1px 0px 0px #FAFAFA, -1px -1px 0px #FAFAFA, 0px -1px 0px #FAFAFA, 1px -1px 0px #FAFAFA, 1px 4px 5px #aeaeae;color:#050505 "
 		}, {
-		  "ptype": "gxp_featuremanager",
-		  "id": "featuremanager",
-		  "autoLoadFeatures":true,
-		  "pagingType":1,
-			"maxFeatures":15
-	    }, 
-	     {	
-		 	"ptype": "gxp_featureeditor",
-    		"featureManager": "featuremanager",
-    		"autoLoadFeatures": "true"
-	    },{
-		  "ptype": "gxp_featuregrid",
-		  "featureManager": "featuremanager",
-		
-		  "outputConfig": {
-			  "id": "featuregrid",
-			  "title": "Features"
-				 		
-		  },
-		  "outputTarget": "south",
-		  "exportFormats": ["CSV","shape-zip"]
-	    }, {
-          "ptype": "gxp_spatialqueryform",
-          "featureManager": "featuremanager",
-          "featureGridContainer": "south",
-          "outputTarget": "east",
-          "showSelectionSummary": true,
-          "actions": null,
-          "id": "bboxquery",
-          "outputConfig":{
-                  "outputSRS": "EPSG:900913",
-                  "selectStyle":{
-                          "strokeColor": "#ee9900",
-                          "fillColor": "#ee9900",
-                          "fillOpacity": 0.4,
-                          "strokeWidth": 1
-                  },
-                  "spatialFilterOptions": {    
-                          "lonMax": 20037508.34,  
-                          "lonMin": -20037508.34,
-                          "latMax": 20037508.34,  
-                          "latMin": -20037508.34  
-                  },
-                  "bufferOptions": {
-                        "minValue": 1,
-                        "maxValue": 1000,
-                        "decimalPrecision": 2,
-                        "distanceUnits": "m"
-                  }
-          },
-          "spatialSelectorsConfig":{
-                "bbox":{
-                    "xtype": "gxp_spatial_bbox_selector"
-                },
-                "buffer":{
-                    "xtype": "gxp_spatial_buffer_selector"
-                },
-                "circle":{
-                    "xtype": "gxp_spatial_circle_selector",
-                    "zoomToCurrentExtent": true
-                },
-                "polygon":{
-                    "xtype": "gxp_spatial_polygon_selector"
-                }
-              }
-        }, {
 			"ptype": "gxp_addlayer",
 			"showCapabilitiesGrid": true,
 			"useEvents": false,
@@ -224,21 +146,114 @@
 		}, {
 			"ptype": "gxp_languageselector",
 			"actionTarget": {"target": "panelbbar", "index": 3}
-		}, 	{
+		}, {
+			"ptype": "gxp_wmsgetfeatureinfo_menu", 
+			"regex": "[\\s\\S]*[\\w]+[\\s\\S]*",
+			"useTabPanel": true,
+			"toggleGroup": "toolGroup",
+			"actionTarget": {"target": "paneltbar", "index": 20}
+		}
+	],
+	"tools": [
+		{
+			"ptype": "gxp_layertree",
+			"outputConfig": {
+				"id": "layertree"
+			},
+			"outputTarget": "tree",
+			"localIndexs":{
+					"it": 0,
+					"de": 1,
+					"en": 2,
+					"fr": 3
+			}
+		}, {
+			"ptype": "gxp_legend",
+			"outputTarget": "legend",
+			"outputConfig": {
+				"autoScroll": true
+			},
+			"legendConfig" : {
+				"legendPanelId" : "legendPanel",
+				"defaults": {
+					"style": "padding:5px",                  
+					"baseParams": {
+						"FORMAT": "image/jpeg",
+						"LEGEND_OPTIONS": "forceLabels:on;fontSize:10",
+						"WIDTH": 20, "HEIGHT": 20
+					}
+				}
+			}
+		}, {
+			"ptype": "gxp_addlayers",
+			"actionTarget": "tree.tbar",
+			"id": "addlayers"
+		}, {
+			"ptype": "gxp_removelayer",
+			"actionTarget": ["tree.tbar", "layertree.contextMenu"]
+		}, {
+			"ptype": "gxp_removeoverlays",
+			"actionTarget": "tree.tbar"
+		}, {
+			"ptype": "gxp_addgroup",
+			"actionTarget": "tree.tbar"
+		}, {
+			"ptype": "gxp_removegroup",
+			"actionTarget": ["tree.tbar", "layertree.contextMenu"]
+		}, {
+			"ptype": "gxp_groupproperties",
+			"actionTarget": ["tree.tbar", "layertree.contextMenu"]
+		}, {
+			"ptype": "gxp_layerproperties",
+			"actionTarget": ["tree.tbar", "layertree.contextMenu"]
+		}, {
+			"ptype": "gxp_zoomtolayerextent",
+			"actionTarget": {"target": "layertree.contextMenu", "index": 0}
+		}, {
+			"ptype":"gxp_geonetworksearch",
+			"actionTarget": ["layertree.contextMenu"]
+		}, {
+			"ptype": "gxp_zoomtoextent",
+			"actionTarget": {"target": "paneltbar", "index": 15}
+		}, {
+			"ptype": "gxp_navigation", "toggleGroup": "toolGroup",
+			"actionTarget": {"target": "paneltbar", "index": 16}
+		}, {
+			"actions": ["-"], "actionTarget": "paneltbar"
+		}, {
+			"ptype": "gxp_zoombox", "toggleGroup": "toolGroup",
+			"actionTarget": {"target": "paneltbar", "index": 17}
+		}, {
+			"ptype": "gxp_zoom",
+			"actionTarget": {"target": "paneltbar", "index": 18}
+		}, {
+			"actions": ["-"], "actionTarget": "paneltbar"
+		}, {
+			"ptype": "gxp_navigationhistory",
+			"actionTarget": {"target": "paneltbar", "index": 19}
+		}, {
+			"actions": ["-"], "actionTarget": "paneltbar"
+		}, {
 			"ptype": "gxp_wmsgetfeatureinfo_menu", 
 			"regex": "[\\s\\S]*[\\w]+[\\s\\S]*",
 			"picturesBrowserConfig": {
-				"baseUrl": "http://geocollect.geo-solutions.it/opensdi2-manager/mvc/fileManager/extJSbrowser",
+				"baseUrl": "http://84.33.2.28/opensdi2-manager/mvc/fileManager/extJSbrowser",
 				"folder": "/geocollect/media/punti_abbandono/",
-				"featureProperty": "MY_ORIG_ID",
+				"featureProperty": "id",
 				"urlSuffix":"/2"
 			},
 			"useTabPanel": true,
 			"toggleGroup": "toolGroup",
 			"actionTarget": {"target": "paneltbar", "index": 20}
+		}, {
+			"ptype": "gxp_addlayer",
+			"showCapabilitiesGrid": false,
+			"id": "addlayer"
+		}, {
+			"actions": ["-"], "actionTarget": "paneltbar"
+		}, {
+			"ptype": "gxp_measure", "toggleGroup": "toolGroup",
+			"actionTarget": {"target": "paneltbar", "index": 21}
 		}
-
 	]
-	
-
 }

--- a/mapcomposer/app/static/config/managerConfig.js
+++ b/mapcomposer/app/static/config/managerConfig.js
@@ -4,6 +4,7 @@
    "start":0,
    "limit":20,
    "msmTimeout":30000,
+   "adminUrl": "http://geocollect.geo-solutions.it/opensdi2-manager/",
    "twitter":{
       "via":"geosolutions_it",
       "hashtags":""
@@ -40,7 +41,8 @@
         "loginManager": "loginTool",
         "actionTarget":null
     },{
-        "ptype": "mxp_categoryinitializer"
+        "ptype": "mxp_categoryinitializer",
+        "neededCategories": ["GEOCOLLECT"]
     },{
         "ptype": "mxp_login",
         "pluginId": "loginTool",
@@ -62,7 +64,7 @@
     },{
         "ptype": "mxp_templatemanager",
         "loginManager": "loginTool",
-        "actionTarget":{
+		"actionTarget":{
           "target": "north.tbar",
           "index": 0
         }
@@ -80,6 +82,23 @@
           "target": "north.tbar",
           "index": 2
         }
+    },{ 
+        "ptype": "mxp_geostore_resource_editor",
+        "category": "MAP",
+        
+        "actionTarget":{
+             "target": "north.tbar",
+             "index": 3
+            }
+
+    },{ 
+        "ptype": "mxp_servicemanager",
+        "notDuplicateOutputs":true,
+        "actionTarget":{
+             "target": "north.tbar",
+             "index": 4
+            }
+
     },{
         "ptype": "mxp_login",
         "pluginId": "loginTool",

--- a/mapcomposer/app/static/externals/gxp/src/script/plugins/WMSGetFeatureInfoMenu.js
+++ b/mapcomposer/app/static/externals/gxp/src/script/plugins/WMSGetFeatureInfoMenu.js
@@ -775,7 +775,7 @@ gxp.plugins.WMSGetFeatureInfoMenu = Ext.extend(gxp.plugins.Tool, {
             // We add the field.
             fields.push(fieldName);
         });
-
+		
         var featureGridConfig = {
             xtype: 'gxp_editorgrid',
             readOnly: true,
@@ -793,7 +793,73 @@ gxp.plugins.WMSGetFeatureInfoMenu = Ext.extend(gxp.plugins.Tool, {
                 }
             }
         };
+		if(this.picturesBrowserConfig){
+			 featureGridConfig.title = null;
+			 var view = new Ext.DataView({
+				itemSelector: 'div.thumb-wrap',
+				style:'overflow:auto',
+				ref:'picview',
+				multiSelect: true,
+				title:'Pictures',
+				store: new Ext.data.JsonStore({
+					url: this.picturesBrowserConfig.baseUrl
+					     +'?action=get_filelist&folder='
+						 +this.picturesBrowserConfig.folder
+						 +feature.data[this.picturesBrowserConfig.featureProperty]+this.picturesBrowserConfig.urlSuffix,
+					//url: 'http://84.33.2.28/opensdi2-manager/mvc/fileManager/extJSbrowser?action=get_filelist&folder='+'/geocollect/media/punti_abbandono/'+feature.data["id"]+'/2',
+					autoLoad: true,
+					root: 'data',
+					id:'name',
+					fields:[
+						'name', 'web_path','mtime','size',
+						{name: 'shortName', mapping: 'name'}
+					],
+					listeners:{
+						load:function (store,records,req){
+							if(records.length <= 0 ){
+								view.refOwner.getBottomToolbar( ).hide();
+								view.refOwner.doLayout();
+							}
+						}
+					}
+				}),
 
+				tpl: new Ext.XTemplate(
+					'<tpl for=".">',
+					'<div class="thumb-wrap" id="{name}">',
+					'<div class="thumb"><img height="100px" width="100px" src="'+this.picturesBrowserConfig.baseUrl+'?action=get_image&file={web_path}" class="thumb-img"></div>',
+					'<span>{name}</span></div>',
+					'</tpl>'
+				),
+				listeners:{
+					dblclick:function (scope, index, node, e){
+						window.open(node.getElementsByTagName("img")[0].src);
+					}
+				}
+			});
+			var tpanel = {
+				xtype:'panel',
+				layout:'card',
+				activeItemIndex:0,
+				activeItem:0,
+				bbar: ['->', {
+					ref:'../switch',
+					//hidden:true,
+					iconCls: 'gxp-icon-printsnapshot',
+					text: 'Images',
+					handler: function(btn){
+						var layout = btn.refOwner.getLayout();
+						btn.refOwner.activeItemIndex = btn.refOwner.activeItemIndex == 0 ? 1 :0;
+						layout.setActiveItem(btn.refOwner.activeItemIndex);
+						btn.setText(btn.refOwner.activeItemIndex == 0 ? "Images" :"Attributes");
+						btn.setIconClass(btn.refOwner.activeItemIndex == 0 ? 'gxp-icon-printsnapshot' : 'gxp-icon-csvexport-single') ;
+					}
+				}],
+				title: title,
+				items: [featureGridConfig,view]
+			};
+			return tpanel;
+		}
         return featureGridConfig;
     },
     /** private: method[obtainFromText]

--- a/mapcomposer/app/static/externals/gxp/src/script/plugins/WMSSource.js
+++ b/mapcomposer/app/static/externals/gxp/src/script/plugins/WMSSource.js
@@ -411,6 +411,7 @@ gxp.plugins.WMSSource = Ext.extend(gxp.plugins.LayerSource, {
 			elevations: "elevations" in config ? config.elevations : null,
 			fixed: config.fixed,
 			selected: "selected" in config ? config.selected : false,
+			infoFormat: config.infoFormat,
 			layer: layer
 		}, original.data);
 		
@@ -426,7 +427,8 @@ gxp.plugins.WMSSource = Ext.extend(gxp.plugins.LayerSource, {
 			{name: "fixed", type: "boolean"},
 			{name: "selected", type: "boolean"},
 			{name: "times", type: "string"},
-			{name: "elevations", type: "string"}
+			{name: "elevations", type: "string"},
+			{name: "infoFormat", type: "string"}
 		];
 
 		original.fields.each(function(field) {

--- a/mapcomposer/app/static/theme/app/mapstore.css
+++ b/mapcomposer/app/static/theme/app/mapstore.css
@@ -234,3 +234,28 @@ div#homelogos ul li a:hover {
     
     display: none !important;
 } */
+
+.thumb{
+	background: #dddddd;
+	padding:3px;
+}
+.thumb img{
+	border:1px solid white;
+	height: 60px;
+	width: 80px;
+}
+.thumb-wrap{
+	float: left;
+	margin: 4px;
+	margin-right: 0;
+	padding: 5px;
+}
+.thumb-wrap span{
+	display: block;
+	overflow: hidden;
+	text-align: center;
+}
+.x-view-selected .thumb{
+	background:#8db2e3;
+}
+

--- a/mapcomposer/app/templates/composer.html
+++ b/mapcomposer/app/templates/composer.html
@@ -38,8 +38,8 @@
 
     <script type="text/javascript" src="script/gxp.js"></script> 
 
-    <!--script type="text/javascript" src="script/proj4js.js"></script-->
-	<!--script type="text/javascript" src="script/projCodes.js"></script-->
+    <script type="text/javascript" src="script/proj4js.js"></script>
+    <script type="text/javascript" src="script/projCodes.js"></script>
 
     <!-- GeoExplorer resources -->
     <link rel="stylesheet" type="text/css" href="theme/app/geoexplorer.css" />


### PR DESCRIPTION
An example configuration can be:

{
    "ptype": "gxp_wmsgetfeatureinfo_menu", 
    "regex": "[\\s\\S]*[\\w]+[\\s\\S]*",
    **"picturesBrowserConfig": {
        "baseUrl": "http://localhost:8082/opensdi2-manager/mvc/fileManager/extJSbrowser",
        "folder": "/geocollect/media/punti_abbandono/",
        "featureProperty": "id",
        "urlSuffix":"/2"
    },**
    "useTabPanel": true,
    "toggleGroup": "toolGroup",
    "actionTarget": {"target": "paneltbar", "index": 20}
}