### PR TITLE
Detect application folder by looking for config.js file

### DIFF
--- a/mapcomposer/app/config.js
+++ b/mapcomposer/app/config.js
@@ -125,10 +125,16 @@ if(environment.applicationPath) {
 		var application = null;
 		var files = applicationsFolder.getResources(true);
 		
-		for(var i = 0, l = files.length; i < l && i < 1; i++) {
+		for(var i = 0, l = files.length; i < l; i++) {
 			var file = files[i].path;
-			file = file.substring(applicationsFolder.path.length);
-			application = file.split('/')[0];
+            // Looks for the first folder containing a config.js file
+            if(file.lastIndexOf("config.js") > -1 ){
+                
+                file = file.substring(applicationsFolder.path.length);
+                application = file.split('/config.js')[0];
+                
+                break;
+            }
 		}
 		
 		if(application) {


### PR DESCRIPTION
This should fix #557 .
Applications can live inside subdirectories, enabling the ant "application" property to be set as
-Dapplication=parent_folder/application_folder

I have tested this change with the default MapStore, the example application and the GeoCollect application.
