### PR TITLE
Add remote sorting option to FeatureManager.

### DIFF
--- a/mapcomposer/app/static/externals/gxp/src/script/data/WFSFeatureStore.js
+++ b/mapcomposer/app/static/externals/gxp/src/script/data/WFSFeatureStore.js
@@ -55,7 +55,8 @@ gxp.data.WFSFeatureStore = Ext.extend(GeoExt.data.FeatureStore, {
                 schema: config.schema,
                 filter: config.ogcFilter,
                 maxFeatures: config.maxFeatures,
-				viewparams: config.viewparams
+				viewparams: config.viewparams,
+                sortBy: config.sortBy
             }, config.proxy));
         }
         if(!config.writer) {

--- a/mapcomposer/app/static/externals/gxp/src/script/data/WFSProtocolProxy.js
+++ b/mapcomposer/app/static/externals/gxp/src/script/data/WFSProtocolProxy.js
@@ -70,7 +70,8 @@ gxp.data.WFSProtocolProxy = Ext.extend(GeoExt.data.ProtocolProxy, {
                 schema: config.schema,
                 filter: config.filter,
                 maxFeatures: config.maxFeatures,
-				viewparams: config.viewparams
+				viewparams: config.viewparams,
+                sortBy: config.sortBy
             }, config.protocol));
         }
 
@@ -99,6 +100,16 @@ gxp.data.WFSProtocolProxy = Ext.extend(GeoExt.data.ProtocolProxy, {
         // remove the xaction param tagged on because we're using a single url
         // for all actions
         delete params.xaction;
+        var sort = params.sort;
+        var dir = params.dir;
+        params.sort = undefined;
+        params.dir = undefined; 
+        if(sort){
+            arg.sortBy = {
+                property: sort,
+                order: dir
+            }
+        }
         
         if (action === Ext.data.Api.actions.read) {
             this.load(params, reader, callback, scope, arg);

--- a/mapcomposer/app/static/externals/gxp/src/script/plugins/FeatureGrid.js
+++ b/mapcomposer/app/static/externals/gxp/src/script/plugins/FeatureGrid.js
@@ -272,6 +272,11 @@ gxp.plugins.FeatureGrid = Ext.extend(gxp.plugins.ClickableFeatures, {
      *  ``String``
      */
 	pageOfLabel: "of",	
+    /**
+     * api: config[ignoreFields]
+      ``Array`` do not display these records in grid
+     */
+    ignoreFields:["feature", "state", "fid"],
 	
     /** api: config[totalRecordsLabel]
      *  ``String``
@@ -642,7 +647,7 @@ gxp.plugins.FeatureGrid = Ext.extend(gxp.plugins.ClickableFeatures, {
 			}
 			
             //TODO use schema instead of store to configure the fields
-            var ignoreFields = ["feature", "state", "fid"];
+            var ignoreFields = this.ignoreFields;
             schema && schema.each(function(r) {
                 r.get("type").indexOf("gml:") == 0 && ignoreFields.push(r.get("name"));
             });

--- a/mapcomposer/app/static/externals/gxp/src/script/plugins/FeatureManager.js
+++ b/mapcomposer/app/static/externals/gxp/src/script/plugins/FeatureManager.js
@@ -703,6 +703,8 @@ gxp.plugins.FeatureManager = Ext.extend(gxp.plugins.Tool, {
                         maxFeatures: this.maxFeatures,
                         layer: this.featureLayer,
                         ogcFilter: filter,
+                        sortBy: this.sortBy,
+                        remoteSort:this.remoteSort,
                         autoLoad: autoLoad,
                         autoSave: false,
                         listeners: {


### PR DESCRIPTION
When pagination is normal (not QuadTree), this option is useful to sort the layers in the feature manager globally (not only the current page). This pull request fix #561.
This means that a FeatureGrid joined to a FeatureManager with this option set, will be able to sort globally clicking on column controls. 
It is implemented adding also support in the OpenLayers WFST format v1_1_0 and in the WFSProtocolProxy. 

this pull request externalize also the ignoreFields in the FeatureGrid widget to make it configurable properly. 
