### PR TITLE
Configurable QRCode Menu

### DIFF
--- a/mapcomposer/app/static/externals/mapmanager/src/MSMGridPanel.js
+++ b/mapcomposer/app/static/externals/mapmanager/src/MSMGridPanel.js
@@ -555,19 +555,22 @@ MSMGridPanel = Ext.extend(Ext.grid.GridPanel, {
         });
         // //////////////
         // QR CODE MENU 
+        // Example of QRCode Menu configuration
+        //
+        //  "embedLink": {
+        //      "embeddedTemplateName": "viewer",
+        //      "showDirectURL": true,
+        //      "showQRCode":true,
+        //      "qrCodeSize":128,
+        //      "showMapStoreMobileSource":true,
+        //      "appDownloadUrl":"http://demo.geo-solutions.it/share/mapstoremobile/MapStoreMobile.apk"
+        //  }
         // //////////////
         var showQR = (this.config.embedLink.showQRCode ==true && !Ext.isIE7 && !Ext.isIE8 && !Ext.isIE6);
         var size = config.embedLink.qrCodeSize;
         
-        this.QRCodeMenu=Ext.apply({config:config}, {
-        text: this.mobileText,
-        disabled: !showQR,
-        iconCls: 'ic_mobile',
-        menu: {
-            xtype: 'menu',
-            plain: true,
-            
-                items: [{
+        var qrcodeMenuItems = [
+                {
                     text: this.installApplicationText,
                     iconCls: 'ic_qrcode',
                     scope:this,
@@ -611,7 +614,14 @@ MSMGridPanel = Ext.extend(Ext.grid.GridPanel, {
                         });
                         win.show();
                     }
-                },{
+                }
+        ];
+        
+        // Shows the "Add this source to MapStoreMobile" menu, default true
+        if(!config.embedLink.hasOwnProperty("showMapStoreMobileSource")
+            || config.embedLink.showMapStoreMobileSource == true){
+            
+            qrcodeMenuItems.push({
                     iconCls: 'ic_qrcode',
                     text: this.loadThisSourceText,
                     tooltip: 'Share This Source',
@@ -655,7 +665,17 @@ MSMGridPanel = Ext.extend(Ext.grid.GridPanel, {
                         });
                         win.show();
                     }
-                }]
+                });
+        }
+        
+        this.QRCodeMenu=Ext.apply({config:config}, {
+        text: this.mobileText,
+        disabled: !showQR,
+        iconCls: 'ic_mobile',
+        menu: {
+            xtype: 'menu',
+            plain: true,
+            items: qrcodeMenuItems
             }
         });
         // //////////////


### PR DESCRIPTION
MapStore Manager improvement.
Enable to configure the visibility of the "Add this source to MapStore Mobile" menu item.

Example of configuration:
```
"embedLink": {
	"embeddedTemplateName": "viewer",
        "showDirectURL": true,
        "showQRCode":true,
        "qrCodeSize":128,
        "showMapStoreMobileSource":false,  // This will hide the second menu item
        "appDownloadUrl":"http://demo.geo-solutions.it/share/mapstoremobile/MapStoreMobile.apk"
	}
```