### PR TITLE
Added possibility to set property fractionalZoom to true in configuration in order to allow zooming to an arbitrary level (between the min and max resolutions)

### DIFF
--- a/mapcomposer/app/static/config/mapStoreConfigGeoScopio.js
+++ b/mapcomposer/app/static/config/mapStoreConfigGeoScopio.js
@@ -1,0 +1,311 @@
+{
+   "scaleOverlayMode": "advanced",
+   "actionToolScale": "medium",   
+   "tab": false,
+   "gsSources":{
+   		"geoscopio": {
+			"ptype": "gxp_wmssource",
+			"url": "http://www502.regione.toscana.it/wmsraster/com.rt.wms.RTmap/wms?map=wmssfondo&map_resolution=91&language=ita",
+			"title": "Geoscopio sfondo",
+			"SRS": "EPSG:3003",
+			"version":"1.3.0",
+            "loadingProgress": true,
+			"layerBaseParams":{
+				"FORMAT":"image/png",
+				"TILED":false
+			}
+		},
+		"geoscopio_topogr": {
+			"ptype": "gxp_wmssource",
+			"url": "http://www502.regione.toscana.it/wmsraster/com.rt.wms.RTmap/wms?map=wmstopogr&version=1.3.0&map_resolution=91&map_mnt=cartoteca&",
+			"title": "Geoscopio Basi Topografiche",
+			"SRS": "EPSG:3003",
+			"version": "1.3.0",
+            "loadingProgress": true,
+			"layerBaseParams": {
+				"FORMAT": "image/png",
+				"TILED": false
+			}
+		},
+		"geoscopio_ambcens": {
+			"ptype": "gxp_wmssource",
+			"url": "http://www502.regione.toscana.it/wmsraster/com.rt.wms.RTmap/wms?map=wmsambcens&version=1.3.0&map_resolution=91&map_mnt=cartoteca&",
+			"title": "Geoscopio Ambiti Censuari",
+			"SRS": "EPSG:3003",
+			"version": "1.3.0",
+            "loadingProgress": true,
+			"layerBaseParams": {
+				"FORMAT": "image/png",
+				"TILED": false
+			}
+		},        
+   		"geoscopio_ortofoto": {
+			"ptype": "gxp_wmssource",
+			"url": "http://web.regione.toscana.it/wmsraster/com.rt.wms.RTmap/wms?map=wmsofc",
+			"title": "Geoscopio ortofoto",
+			"SRS": "EPSG:3003",
+			"version":"1.3.0",
+            "loadingProgress": true,
+			"layerBaseParams":{
+				"FORMAT":"image/png",
+				"TILED":false
+			}
+		},
+   		"geoscopio_ctr": {
+			"ptype": "gxp_wmssource",
+			"url": "http://web.regione.toscana.it/wmsraster/com.rt.wms.RTmap/wms?map=wmsctr",
+			"title": "Geoscopio CTR",
+			"SRS": "EPSG:3003",
+			"version":"1.3.0",
+            "loadingProgress": true,
+			"layerBaseParams":{
+				"FORMAT":"image/png",
+				"TILED":false
+			}
+		},
+   		"geoscopio_idrografia": {
+			"ptype": "gxp_wmssource",
+			"url": "http://web.regione.toscana.it/wmsraster/com.rt.wms.RTmap/wms?map=wmsidrogr&map_resolution=91&language=ita&",
+			"title": "Geoscopio idrografia",
+			"SRS": "EPSG:3003",
+			"version":"1.3.0",
+            "loadingProgress": true,		
+			"layerBaseParams":{
+				"FORMAT":"image/png",
+				"TILED":false
+			}
+		},
+   		"geoscopio_amb_ammin": {
+			"ptype": "gxp_wmssource",
+			"url": "http://www502.regione.toscana.it/wmsraster/com.rt.wms.RTmap/wms?map=wmsambamm&",
+			"title": "Geoscopio ambiti amministrativi",
+			"SRS": "EPSG:3003",
+			"version":"1.3.0",
+            "loadingProgress": true,		
+			"layerBaseParams":{
+				"FORMAT":"image/png",
+				"TILED":false
+			}
+		}
+	},
+	"loadingPanel": {
+		"width": 100,
+		"height": 100,
+		"center": true
+	},
+	"map": {
+		"projection": "EPSG:3003",
+		"displayProjection": "EPSG:3003",
+		"units": "m",
+		"fractionalZoom": true,
+		"center": [1671579.00, 4803992.00],
+		"scales": [50, 1000, 2000, 5000, 8000, 10000, 15000, 25000, 50000, 100000, 250000, 500000, 1000000, 1500000, 2000000],
+		"maxExtent": [1328298.3134386, 4554791.501599, 2014859.6865614, 5053192.498401],
+		"restrictedExtent": [1550750, 4674330, 1775720, 4929790],    
+		"layers": [{
+                "source": "geoscopio",
+                "group": "background",
+                "title": "Basi di sfondo",
+                "name": "rt_sfondo.batimetriche",
+                "displayInLayerSwitcher": true,
+                "visibility": true,
+                "tiled": false,
+                "attribution": false
+            },
+            {
+                "source": "geoscopio",
+                "group": "background",
+                "title": "Basi di sfondo",
+                "name": "rt_sfondo.intorno_toscana",
+                "displayInLayerSwitcher": false,
+                "visibility": true,
+                "tiled": false,
+                "attribution": false
+            },
+            {
+                "source": "geoscopio_ortofoto",
+                "group": "Ortofotocarte 1:10.000",
+                "title": "Anno 2013 col - AGEA",
+                "name": "rt_ofc.10k13",
+                "displayInLayerSwitcher": true,
+                "visibility": false,
+                "tiled": false,
+                "attribution": false
+            },
+            {
+                "source": "geoscopio_ortofoto",
+                "group": "Ortofotocarte 1:10.000",
+                "title": "Anno 2010 col - AGEA",
+                "name": "rt_ofc.10k10",
+                "displayInLayerSwitcher": true,
+                "visibility": false,
+                "tiled": false,           
+                "attribution": false
+            },
+            {
+                "source": "geoscopio_ortofoto",
+                "group": "Ortofotocarte 1:10.000",
+                "title": "Anno 2007 col - CGR",
+                "name": "rt_ofc.10k07",
+                "displayInLayerSwitcher": true,
+                "visibility": false,
+                "tiled": false,        
+                "attribution": false
+            },
+            {
+                "source": "geoscopio_ortofoto",
+                "group": "Ortofotocarte 1:10.000",
+                "title": "Anno 1996 bn - AIMA",
+                "name": "rt_ofc.10k96",
+                "displayInLayerSwitcher": true,
+                "visibility": false,
+                "tiled": false,        
+                "attribution": false
+            },
+            {
+                "source": "geoscopio_ortofoto",
+                "group": "Ortofotocarte 1:10.000",
+                "title": "Anno 1988 bn - RT",
+                "name": "rt_ofc.10k88",
+                "displayInLayerSwitcher": true,
+                "visibility": false,
+                "tiled": false,       
+                "attribution": false
+            },
+            {
+                "source": "geoscopio_ortofoto",
+                "group": "Ortofotocarte 1:10.000",
+                "title": "Anno 1978 bn - RT",
+                "name": "rt_ofc.10k78",
+                "displayInLayerSwitcher": true,
+                "visibility": false,
+                "tiled": false,         
+                "attribution": false
+            },
+            {
+                "source": "geoscopio_ortofoto",
+                "group": "Ortofotocarte 1:10.000",
+                "title": "Anno 1954 bn - RT-IGM",
+                "name": "rt_ofc.10k54",
+                "displayInLayerSwitcher": true,
+                "visibility": false,
+                "tiled": false,          
+                "attribution": false
+            },
+            {
+                "source": "geoscopio_topogr",
+                "group": "Basi cartografiche",
+                "title": "Carta Topografica 50k",
+                "maxscale": 15000, 
+                "name": "rt_topogr.topografica50k.grey.rt",
+                "displayInLayerSwitcher": true,
+                "visibility": true,
+                "tiled": false,
+                "attribution": false
+            },
+            {
+                "source": "geoscopio_ctr",
+                "group": "Basi cartografiche",
+                "title": "CTR 1:10.000 Raster BW",
+                "name": "rt_ctr.10k",
+                "minscale": 15000,             
+                "displayInLayerSwitcher": true,
+                "visibility": true,
+                "tiled": false,
+                "attribution": false
+            },
+            {
+                "source": "geoscopio_ctr",
+                "group": "Basi cartografiche",
+                "title": "CTR 1:10.000 Raster GL",
+                "minscale": 15000,            
+                "name": "rt_ctr.ctr10kgreylight",
+                "displayInLayerSwitcher": true,
+                "visibility": false,
+                "tiled": false,
+                "attribution": false
+            },
+            {
+                "source": "geoscopio_ambcens",
+                "group": "Toponimi",
+                "title": "Toponimi - Centri e nuclei 2011",
+                "name": "rt_amb_cens.centri_nuclei_2011",
+                "displayInLayerSwitcher": true,
+                "visibility": true,
+                "tiled": false,
+                "attribution": false
+            },{
+				"source": "geoscopio_amb_ammin",
+				"group": "Ambiti amministrativi",
+				"title": "Province",
+				"name": "rt_ambamm.idprovince.rt.poly",
+				"displayInLayerSwitcher": true,
+				"visibility": true,
+				"tiled": false,
+                "attribution": false
+			},{
+				"source": "geoscopio_amb_ammin",
+				"group": "Ambiti amministrativi",
+				"title": "Comuni",
+				"name": "rt_ambamm.idcomuni.rt.poly",
+				"displayInLayerSwitcher": true,
+				"visibility": false,
+				"tiled": false,
+                "attribution": false
+			}
+		]
+	},
+    "removeTools": [
+        "wmsgetfeatureinfo_menu_plugin"
+    ], 	
+	"proj4jsDefs": {
+		"EPSG:3003": "+proj=tmerc +lat_0=0 +lon_0=9 +k=0.9996 +x_0=1500000 +y_0=0 +ellps=intl +units=m +no_defs +towgs84 = -104.1,-49.1,-9.9,0.971,-2.917,0.714,-11.68"
+	},   
+	"customTools": [
+		{
+			"ptype": "gxp_embedmapdialog",
+			"actionTarget": {"target": "paneltbar", "index": 2},
+			"embeddedTemplateName": "viewer",
+			"showDirectURL": true
+		},{
+            "ptype":"gxp_wmsgetfeatureinfo",
+            "id": "wmsgetfeatureinfo_plugin",
+            "toggleGroup":"toolGroup",
+            "closePrevious": true,
+            "useTabPanel": true,
+            "infoPanelId": "",
+            "disableAfterClick": false,
+            "loadingMask": true,
+			"maxFeatures": 100,
+            "actionTarget":{
+                "target":"paneltbar",
+                "index":14
+            }
+        }, {
+		   "ptype": "gxp_mouseposition",
+		   "displayProjectionCode":"EPSG:3003",
+		   "customCss": "font-weight: bold; text-shadow: 1px 0px 0px #FAFAFA, 1px 1px 0px #FAFAFA, 0px 1px 0px #FAFAFA,-1px 1px 0px #FAFAFA, -1px 0px 0px #FAFAFA, -1px -1px 0px #FAFAFA, 0px -1px 0px #FAFAFA, 1px -1px 0px #FAFAFA, 1px 4px 5px #aeaeae;color:#050505"
+		}, {
+			"ptype": "gxp_addlayer",
+			"showCapabilitiesGrid": true,
+			"useEvents": false,
+			"showReport": false,
+			"directAddLayer": false,
+			"id": "addlayer"
+		}, {
+			"actions": ["-"], 
+			"actionTarget": "paneltbar"
+		}, {
+			"ptype": "gxp_geolocationmenu",
+			"actionTarget": {"target": "paneltbar", "index": 23},
+			"toggleGroup": "toolGroup"
+		}, {
+            "ptype": "gxp_about",
+            "poweredbyURL": "http://www.geo-solutions.it/about/contacts/",
+            "actionTarget": {
+                "target": "panelbbar",
+                "index": 1
+            }
+        }
+	]
+}

--- a/mapcomposer/app/static/externals/gxp/src/script/plugins/WMSSource.js
+++ b/mapcomposer/app/static/externals/gxp/src/script/plugins/WMSSource.js
@@ -408,7 +408,7 @@ gxp.plugins.WMSSource = Ext.extend(gxp.plugins.LayerSource, {
 			config.title || config.name, 
 			layer.url, 
 			params, {
-				attribution: layer.attribution,
+				attribution: ("attribution" in config) ? (config.attribution ? layer.attribution : '') : layer.attribution,
 				maxExtent: maxCachedExtent,
 				restrictedExtent: maxExtent,
 				displayInLayerSwitcher: ("displayInLayerSwitcher" in config) ? config.displayInLayerSwitcher :true,
@@ -421,7 +421,9 @@ gxp.plugins.WMSSource = Ext.extend(gxp.plugins.LayerSource, {
 				dimensions: original.data.dimensions,
 				projection: layerProjection,
 				vendorParams: config.vendorParams,
-				transitionEffect: transitionEffect
+				transitionEffect: transitionEffect,
+                minScale: config.minscale,
+                maxScale: config.maxscale             
 			}
 		);
 

--- a/mapcomposer/app/static/externals/gxp/src/script/widgets/ScaleOverlay.js
+++ b/mapcomposer/app/static/externals/gxp/src/script/widgets/ScaleOverlay.js
@@ -54,7 +54,7 @@ gxp.ScaleOverlay = Ext.extend(Ext.Panel, {
     
     /** i18n */
     zoomLevelText: "Zoom level",
-
+	
     /** private: method[initComponent]
      *  Initialize the component.
      */
@@ -141,8 +141,10 @@ gxp.ScaleOverlay = Ext.extend(Ext.Panel, {
             }else{ 
                 Ext.get("id_box").insertBefore(Ext.get("zoom_selector"));               
             }
-            this.getEl().on("click", this.stopMouseEvents, this);
-            this.getEl().on("mousedown", this.stopMouseEvents, this);
+			if(!this._fractionalZoom){
+				this.getEl().on("click", this.stopMouseEvents, this);
+				this.getEl().on("mousedown", this.stopMouseEvents, this);
+			}
         }, this);
         
         this.scaleLinePanel.on('render', function(){
@@ -176,12 +178,22 @@ gxp.ScaleOverlay = Ext.extend(Ext.Panel, {
         }, this);
         if (scale.length > 0) {
             scale = scale.items[0];
-            this.zoomSelector.setValue("1 : " + parseInt(scale.data.scale, 10));
+            this.zoomSelector.setValue(
+				!this._fractionalZoom ?
+				'1 : ' + parseInt(Math.round(scale.data.scale,10)) :
+				'1 : ' + Ext.util.Format.number(parseInt(Math.round(scale.data.scale,10)),'0.000/i')
+			);
         } else {
             if (!this.zoomSelector.rendered) {
                 return;
             }
-            this.zoomSelector.clearValue();
+			// to manage fractionalZoom = true			
+			if(!this._fractionalZoom){
+				this.zoomSelector.clearValue();
+			}else{
+				var fractionalScale = parseInt(Math.round(this.map.getScale()),10);
+				this.zoomSelector.setValue("1 : " + Ext.util.Format.number(fractionalScale,'0.000/i'));				
+			}
         }
     },
 
@@ -190,24 +202,54 @@ gxp.ScaleOverlay = Ext.extend(Ext.Panel, {
      *  Create the scale combo and add it to the panel.
      */
     addScaleCombo: function() {
+		
+		// to manage fractionalZoom = true
+		this._fractionalZoom = this.map.fractionalZoom || false;
+		
         this.zoomStore = new GeoExt.data.ScaleStore({
             map: this.map
         });       
         this.zoomSelector = new Ext.form.ComboBox({
             emptyText: this.zoomLevelText,
-            tpl: '<tpl for="."><div class="x-combo-list-item">1 : {[parseInt(values.scale)]}</div></tpl>',
-            editable: false,
+            tpl: !this._fractionalZoom ?
+				'<tpl for="."><div class="x-combo-list-item">1 : {[parseInt(Math.round(values.scale))]}</div></tpl>' :
+				'<tpl for="."><div class="x-combo-list-item">1 : {[Ext.util.Format.number(parseInt(Math.round(values.scale)),\'0.000/i\')]}</div></tpl>',
+            editable: this._fractionalZoom,
             triggerAction: 'all',
             mode: 'local',
             store: this.zoomStore,
-            width: 110
+            width: 110,
+			enableKeyEvents: this._fractionalZoom, // to manage fractionalZoom = true
+			maskRe: /^\d{0,9}$/,
+			selectOnFocus: this._fractionalZoom
         });
         this.zoomSelector.on({
-            click: this.stopMouseEvents,
-            mousedown: this.stopMouseEvents,
+            click: !this._fractionalZoom ? this.stopMouseEvents : 'undefined',
+            mousedown: !this._fractionalZoom ? this.stopMouseEvents : 'undefined',
             select: function(combo, record, index) {
-                this.map.zoomTo(record.data.level);
+				this.map.zoomTo(record.data.level);
             },
+			specialkey: function(combo, e){
+				if (e.getKey() == e.ENTER) {
+					var scale, zoomSelectorValue;
+					zoomSelectorValue = combo.getValue().replace(/[\. ,-]+/g, '');
+                    
+                    if (zoomSelectorValue === ''){
+                        var comboStore = combo.getStore();
+                        var count = comboStore.getCount();
+                        var record = comboStore.getAt(0);
+                        var startValue = record.get('scale');
+                        scale = parseInt(startValue, 10);                        
+					}else if(zoomSelectorValue.indexOf(":") !== -1){
+						var zoomSelectorValueArray = zoomSelectorValue.split(":");
+						scale = parseInt(zoomSelectorValueArray[1], 10);
+					}else{
+						scale = parseInt(zoomSelectorValue, 10);
+					}
+					
+					this.map.zoomToScale(scale,false);
+				}
+			},
             scope: this
         });
         this.map.events.register('zoomend', this, this.handleZoomEnd);

--- a/mapcomposer/app/static/externals/gxp/src/script/widgets/Viewer.js
+++ b/mapcomposer/app/static/externals/gxp/src/script/widgets/Viewer.js
@@ -412,7 +412,7 @@ gxp.Viewer = Ext.extend(Ext.util.Observable, {
         
         // split initial map configuration into map and panel config
         if (this.initialConfig.map) {
-            var props = "theme,controls,resolutions,projection,units,maxExtent,restrictedExtent,maxResolution,numZoomLevels,animatedZooming".split(",");
+            var props = "theme,controls,resolutions,projection,units,maxExtent,restrictedExtent,maxResolution,numZoomLevels,animatedZooming,scales,fractionalZoom".split(",");
             var prop;
             for (var i=props.length-1; i>=0; --i) {
                 prop = props[i];
@@ -464,7 +464,7 @@ gxp.Viewer = Ext.extend(Ext.util.Observable, {
 				zoomMethod: zoomMethod
             }, mapConfig),
             center: config.center && new OpenLayers.LonLat(config.center[0], config.center[1]),
-            resolutions: config.resolutions,
+            resolutions: config.resolutions,	
             layers: [new OpenLayers.Layer(null, baseLayerConfig)],
             items: this.mapItems,
             tbar: config.tbar || {hidden: true}

--- a/mapcomposer/app/static/externals/proj4js/lib/defs/EPSG3003.js
+++ b/mapcomposer/app/static/externals/proj4js/lib/defs/EPSG3003.js
@@ -1,0 +1,1 @@
+Proj4js.defs["EPSG:3003"] = "+proj=tmerc +lat_0=0 +lon_0=9 +k=0.9996 +x_0=1500000 +y_0=0 +ellps=intl +units=m +no_defs +towgs84 = -104.1,-49.1,-9.9,0.971,-2.917,0.714,-11.68";

--- a/mapcomposer/app/templates/composer.html
+++ b/mapcomposer/app/templates/composer.html
@@ -38,8 +38,8 @@
 
     <script type="text/javascript" src="script/gxp.js"></script> 
 
-    <!--script type="text/javascript" src="script/proj4js.js"></script-->
-	<!--script type="text/javascript" src="script/projCodes.js"></script-->
+    <script type="text/javascript" src="script/proj4js.js"></script>
+	<script type="text/javascript" src="script/projCodes.js"></script>
 
     <!-- GeoExplorer resources -->
     <link rel="stylesheet" type="text/css" href="theme/app/geoexplorer.css" />
@@ -432,9 +432,19 @@
                         westPanel.setActiveTab('legend');
                         westPanel.hideTabStripItem('tree');
                     }
+					
+					/////////////////////
+					// Fractional Zoom //
+					/////////////////////
+                    if(app.mapPanel.map.restrictedExtent && app.mapPanel.map.fractionalZoom){
+                        app.mapPanel.map.zoomToExtent(app.mapPanel.map.restrictedExtent);
+                    }
+					
                 }, 
                 'ready' : function(){
                     app.modified = false;
+
+
 					
 					// ///////////////////////////////////////////////////
 					// Visualizing metadata tab and layers at startup 


### PR DESCRIPTION
This is a small improvement about Scale Overlay and Advanced Scale Overlay plugin.
What I did is make configurable map.fractionalZoom property and make editable the scale selector in order to allow the user to enter the value of scale of interest.

This is openlayers's example: http://dev.openlayers.org/examples/fractional-zoom.html

In the commit is also present:
mapStoreConfigGeoScopio.js - the configuration file where you set the fractionalZoom and that you can use to test the new functionality

If fractionalZoom is not set or if it is set to false, the plugins work as always

Description of map.fractionalZoom property:

/**
 * Property: fractionalZoom
 * {Boolean} For a base layer that supports it, allow the map resolution
 *     to be set to a value between one of the values in the resolutions
 *     array.  Default is false.
 *
 * When fractionalZoom is set to true, it is possible to zoom to
 *     an arbitrary extent.  This requires a base layer from a source
 *     that supports requests for arbitrary extents (i.e. not cached
 *     tiles on a regular lattice).  This means that fractionalZoom
 *     will not work with commercial layers (Google, Yahoo, VE), layers
 *     using TileCache, or any other pre-cached data sources.
 *
 * If you are using fractionalZoom, then you should also use
 *     <getResolutionForZoom> instead of layer.resolutions[zoom] as the
 *     former works for non-integer zoom levels.
 */	