### PR TITLE
Added extrafilds to getFeatureinfo menu close #618 and geosolutions-it/npa-cgg#19

### DIFF
--- a/mapcomposer/app/static/externals/gxp/src/script/plugins/FeatureEditorGrid.js
+++ b/mapcomposer/app/static/externals/gxp/src/script/plugins/FeatureEditorGrid.js
@@ -91,6 +91,9 @@ gxp.plugins.FeatureEditorGrid = Ext.extend(Ext.grid.PropertyGrid, {
             // determine the order of attributes
             attributes = {};
             for (var i=0,ii=this.fields.length; i<ii; ++i) {
+                if(typeof this.fields[i]=='object')
+                attributes[this.fields[i].name] = feature.attributes;
+                else
                 attributes[this.fields[i]] = feature.attributes[this.fields[i]];
             }
         } else {

--- a/mapcomposer/app/static/externals/gxp/src/script/plugins/WMSGetFeatureInfoMenu.js
+++ b/mapcomposer/app/static/externals/gxp/src/script/plugins/WMSGetFeatureInfoMenu.js
@@ -888,7 +888,7 @@ if(this.infoAction=='click'){
     obtainFeatureGrid: function(feature, title){
 
         var fields = [];
-        var lname=feature.gml.featureNSPrefix+":"+feature.gml.featureType;
+        var lname=(feature.gml.featureNSPrefix)?feature.gml.featureNSPrefix+":"+feature.gml.featureType:feature.gml.featureType;
         var ignoreFields=(this.outputGridConfig && this.outputGridConfig[lname] &&  this.outputGridConfig[lname].ignoreFields)?this.outputGridConfig[lname].ignoreFields:[];
         var propertyNames=(this.outputGridConfig && this.outputGridConfig[lname] &&  this.outputGridConfig[lname].propertyNames)?this.outputGridConfig[lname].propertyNames:null;
         var extraFields=(this.outputGridConfig && this.outputGridConfig[lname] &&  this.outputGridConfig[lname].extraFields)?this.outputGridConfig[lname].extraFields:null;


### PR DESCRIPTION
It's possible to configure WMSGetFeatureInfoMenu with outputGridConfig param.
Example
```
"outputGridConfig":{
"npa:footprints":{ //layer name
"ignoreFields":["track_dir","orbit"], 
"propertyNames":{"location_":"location"}, //header
"extraFields":{"link":"<a href='http://www.geo-solutions.it/'>{location_}</a>"} 
}
}
```
extraFields has a name and a template, template will recive feature.attributes as data.