### PR TITLE
Close #691

### DIFF
--- a/mapcomposer/app/static/config/managerConfig.js
+++ b/mapcomposer/app/static/config/managerConfig.js
@@ -36,6 +36,7 @@
          "Español"
       ]
    ],
+   "cookieConsent":{"link":true},
    "tools":[{
         "ptype": "mxp_mapmanager",
         "loginManager": "loginTool",

--- a/mapcomposer/app/static/config/managerConfig.js
+++ b/mapcomposer/app/static/config/managerConfig.js
@@ -36,7 +36,7 @@
          "Español"
       ]
    ],
-   "cookieConsent":{"link":true},
+   "cookieConsent":true,
    "tools":[{
         "ptype": "mxp_mapmanager",
         "loginManager": "loginTool",

--- a/mapcomposer/app/static/config/mapStoreConfig.js
+++ b/mapcomposer/app/static/config/mapStoreConfig.js
@@ -22,7 +22,7 @@
 		"height": 100,
 		"center": true
 	},
-	"cookieConsent":{"link":true},
+	"cookieConsent":true,
 	"map": {
 		"projection": "EPSG:900913",
 		"units": "m",

--- a/mapcomposer/app/static/config/mapStoreConfig.js
+++ b/mapcomposer/app/static/config/mapStoreConfig.js
@@ -22,6 +22,7 @@
 		"height": 100,
 		"center": true
 	},
+	"cookieConsent":{"link":true},
 	"map": {
 		"projection": "EPSG:900913",
 		"units": "m",

--- a/mapcomposer/app/static/config/viewerConfig.js
+++ b/mapcomposer/app/static/config/viewerConfig.js
@@ -23,7 +23,7 @@
         "center": [1250000.000000, 5370000.000000],
         "zoom": 5
     },
-   	"cookieConsent":{"link":false},
+   	"cookieConsent":true,
 
 	"loadingPanel": {
 		"width": 100,

--- a/mapcomposer/app/static/config/viewerConfig.js
+++ b/mapcomposer/app/static/config/viewerConfig.js
@@ -23,6 +23,8 @@
         "center": [1250000.000000, 5370000.000000],
         "zoom": 5
     },
+   	"cookieConsent":{"link":false},
+
 	"loadingPanel": {
 		"width": 100,
 		"height": 100,

--- a/mapcomposer/app/static/cookies-policy-en.html
+++ b/mapcomposer/app/static/cookies-policy-en.html
@@ -40,7 +40,7 @@
 		<div id="wrapper" style="margin: 0 auto;">
 			
 			<div style="position:relative; font-size:13px; padding-left:10px; padding-right:10px;" id="main">
-				<h2 style="font-weight: bold;">Privacy e Cookies Policy</h2>
+				<h2 style="font-weight: bold;">Privacy and Cookies Policy</h2>
 				<hr />					
 				<p style="line-height: 100%;">
 					In accordance with Legislative Decree No. 196/2003, which replaced the Law No. 675/1996 regarding
@@ -116,7 +116,7 @@
 				<p style="line-height: 100%;">
 					The privacy implications on this will vary from social network to social network and will be dependent on the privacy settings you have chosen on these networks.
 				</p>
-				<h4 style="font-weight: bold;">Disabilitare i Cookies</h4>
+				<h4 style="font-weight: bold;">Controlling Cookies</h4>
 				
 				<p style="line-height: 100%;">
 					All browsers allow you to manage which cookies you accept, reject and delete via controls found under the ‘Preferences' or ‘Tools' menu. Further information on deleting or controlling cookies is available 

--- a/mapcomposer/app/static/cookies-policy-en.html
+++ b/mapcomposer/app/static/cookies-policy-en.html
@@ -55,7 +55,7 @@
 					service.
 				</p>
 				
-				<h4 style="font-weight: bold;">Cosa sono i Cookies</h4>
+				<h4 style="font-weight: bold;">What are Cookies</h4>
 				
 				<p style="line-height: 100%;">
 					A cookie is a small piece of text sent to your browser by a website you visit. 

--- a/mapcomposer/app/static/cookies-policy-en.html
+++ b/mapcomposer/app/static/cookies-policy-en.html
@@ -93,12 +93,12 @@
 					If the settings on your software that you are using to view this website (your browser) are adjusted to accept cookies we take this, and your continued use of our website, to mean that you are fine with this. Should you wish to remove or not use cookies from our site you can learn how to do this below, however doing so will likely mean that our site will not work as you would expect.
 				</p>
 				
-				<h4 style="font-weight: bold;">I nostri Cookies</h4>
+				<h4 style="font-weight: bold;">Cookies set by our own Website</h4>
 			   
 				<p style="line-height: 100%;">
 					We use cookies to make our site work, including:
 				</p>
-				
+				 
 				<ul style="padding-left:30px; padding-right:10px;">
 					<li>Determining if you are logged in or not</li>
 					<li>Authentication to services  WMS, WFS, WPS  through HTTP requests</li>	

--- a/mapcomposer/app/static/cookies-policy-en.html
+++ b/mapcomposer/app/static/cookies-policy-en.html
@@ -1,0 +1,133 @@
+<html xmlns="http://www.w3.org/1999/xhtml" lang="en"">
+<head>    
+	<meta http-equiv="content-type" content="text/html; charset=utf-8" />
+	<title>Privacy e Cookies Policy</title>
+   
+    <!-- header style -->
+    <style type="text/css">
+			.body_ovl{
+				font : normal  12px;
+				font-family : Verdana, Helvetica, sans-serif;
+				text-align : left;
+			}
+			
+			.page {
+				z-index: 1;
+				width: 800px;
+				background-image: none;
+				border-width: 1px;
+				border-style: solid;
+				border-color: #000000;
+				background-color: #FFFFFF;
+				padding-bottom: 0px;
+				margin-left: auto;
+				margin-top: 20px;
+				margin-bottom:20px;
+				margin-right: auto;
+				text-align: justify;
+				padding-left:30px;
+				padding-right:30px;
+			}
+			
+			.page p {
+				width: 750px;
+				text-align: justify;
+			}
+	</style>
+</head>
+<body bgcolor="#5A5A5A" class="body_ovl" style="padding-top: 0px; padding-bottom: 0px;">
+	<div class="page">
+		<div id="wrapper" style="margin: 0 auto;">
+			
+			<div style="position:relative; font-size:13px; padding-left:10px; padding-right:10px;" id="main">
+				<h2 style="font-weight: bold;">Privacy e Cookies Policy</h2>
+				<hr />					
+				<p style="line-height: 100%;">
+					In accordance with Legislative Decree No. 196/2003, which replaced the Law No. 675/1996 regarding
+					Personal Data Protection, we inform you that continuing navigation on this site you consent
+					the processing of your personal data (sensitive information will not be treated in any way).
+					Your data will only be used for operations at the site and will not be
+					disclosed to third party companies without your consent. In any case, it is possible
+					exercise the rights granted to you under the Legislative Decree 196/2003 (access to data,
+					updating, cancellation).
+					If you click the "Agree" button, you acknowledge that you have read this text and consent to treatment
+					of personal data. At any time you can ask the staff of the site to delete you from
+					service.
+				</p>
+				
+				<h4 style="font-weight: bold;">Cosa sono i Cookies</h4>
+				
+				<p style="line-height: 100%;">
+					A cookie is a small piece of text sent to your browser by a website you visit. 
+					It helps the website to remember information about your visit, like your preferred language and other settings. 
+					That can make your next visit easier and the site more useful to you.
+					The browser saves the information and forward it to the site server when you visit again
+					that website.		
+				</p>
+				
+				<p style="line-height: 100%;">
+					Our cookies help us to:
+				</p>
+				
+				<ul style="padding-left:30px; padding-right:10px;">
+					<li>Make our website work as you'd expect</li>
+					<li>Remember your settings during and between visits</li>
+					<li>Improve the performance/security of our website</li>
+					<li>Allow you to share pages with social networks like Facebook</li>			
+				</ul>
+				
+				<p style="line-height: 100%;">
+					We do not use cookies to:
+				</p>
+						
+				<ul style="padding-left:30px; padding-right:10px;">
+					<li>Collect any personally identifiable information (without your express permission)</li>
+					<li>Collect any sensitive information (without your express permission)</li>
+					<li>Pass data to advertising networks</li>	
+				</ul>
+				<p style="line-height: 100%;">
+				You can learn more about all the cookies we use below.
+				</p>
+				
+				<p style="line-height: 100%;">
+					If the settings on your software that you are using to view this website (your browser) are adjusted to accept cookies we take this, and your continued use of our website, to mean that you are fine with this. Should you wish to remove or not use cookies from our site you can learn how to do this below, however doing so will likely mean that our site will not work as you would expect.
+				</p>
+				
+				<h4 style="font-weight: bold;">I nostri Cookies</h4>
+			   
+				<p style="line-height: 100%;">
+					We use cookies to make our site work, including:
+				</p>
+				
+				<ul style="padding-left:30px; padding-right:10px;">
+					<li>Determining if you are logged in or not</li>
+					<li>Authentication to services  WMS, WFS, WPS  through HTTP requests</li>	
+				</ul>
+				
+				<h4 style="font-weight: bold;">Social Website Cookies</h4>
+				<p style="line-height: 100%;">
+					To facilitate easy sharing or liking of content on social network platforms such Facebook and Twitter, we have included sharing buttons on our site. Cookies are enabled for:
+				</p>
+				
+				<ul style="padding-left:30px; padding-right:10px;">
+					<li>Twitter</li>
+					<li>Facebook</li>	
+				</ul>
+				<p style="line-height: 100%;">
+					The privacy implications on this will vary from social network to social network and will be dependent on the privacy settings you have chosen on these networks.
+				</p>
+				<h4 style="font-weight: bold;">Disabilitare i Cookies</h4>
+				
+				<p style="line-height: 100%;">
+					All browsers allow you to manage which cookies you accept, reject and delete via controls found under the ‘Preferences' or ‘Tools' menu. Further information on deleting or controlling cookies is available 
+					<a href="http://www.attacat.co.uk/resources/cookies/how-to-ban" target="_blank">here</a>). 
+					Please note however that if you disable cookies you may not be able to access certain services or facilities of this as of  many of the Web sites around the world (cookies are a standard component of most modern websites).
+				</p>
+				
+				<br/><br/><br/>
+				
+			</div>
+		</div>
+	</div>
+	</body>
+</html>

--- a/mapcomposer/app/static/cookies-policy-it.html
+++ b/mapcomposer/app/static/cookies-policy-it.html
@@ -1,0 +1,138 @@
+<html xmlns="http://www.w3.org/1999/xhtml" lang="en"">
+<head>    
+	<meta http-equiv="content-type" content="text/html; charset=utf-8" />
+	<title>Privacy e Cookies Policy</title>
+   
+    <!-- header style -->
+    <style type="text/css">
+			.body_ovl{
+				font : normal  12px;
+				font-family : Verdana, Helvetica, sans-serif;
+				text-align : left;
+			}
+			
+			.page {
+				z-index: 1;
+				width: 800px;
+				background-image: none;
+				border-width: 1px;
+				border-style: solid;
+				border-color: #000000;
+				background-color: #FFFFFF;
+				padding-bottom: 0px;
+				margin-left: auto;
+				margin-top: 20px;
+				margin-bottom:20px;
+				margin-right: auto;
+				text-align: justify;
+				padding-left:30px;
+				padding-right:30px;
+			}
+			
+			.page p {
+				width: 750px;
+				text-align: justify;
+			}
+	</style>
+</head>
+<body bgcolor="#5A5A5A" class="body_ovl" style="padding-top: 0px; padding-bottom: 0px;">
+	<div class="page">
+		<div id="wrapper" style="margin: 0 auto;">
+			
+			<div style="position:relative; font-size:13px; padding-left:10px; padding-right:10px;" id="main">
+				<h2 style="font-weight: bold;">Privacy e Cookies Policy</h2>
+				<hr />					
+				<p style="line-height: 100%;">
+					Ai sensi del Decreto Legislativo n ° 196/2003, che ha sostituito la legge n ° 675/1996 in materia di 
+					protezione dei dati personali, Vi informiamo che proseguendo la navigazione su questo sito voi acconsentite 
+					al trattamento dei vostri dati personali (i dati sensibili non saranno trattati in alcun modo).
+					I suoi dati saranno utilizzati esclusivamente per le operazioni all'interno del sito e non potranno essere 
+					comunicati a società di terze parti senza il vostro consenso. In ogni caso, è possibile 
+					esercitare i diritti concessi all'utente ai sensi del Decreto Legislativo n ° 196/2003 (accesso ai dati, 
+					aggiornamento, integrazione, cancellazione).
+					Facendo clic sul pulsante "Accetto", si dichiara di aver letto questo testo e di acconsentire al trattamento 
+					dei dati personali. In qualsiasi momento è possibile chiedere alla redazione del sito di cancellarti dal 
+					servizio.
+				</p>
+				
+				<h4 style="font-weight: bold;">Cosa sono i Cookies</h4>
+				
+				<p style="line-height: 100%;">
+					Un cookie è un file di testo che un sito web salva sul browser del computer dell’utente. Solitamente i cookie 
+					consentono di memorizzare le preferenze espresse dall’utente per non dover essere reinserite successivamente. 
+					Il browser salva l’informazione e la ritrasmette al server del sito nel momento in cui l’utente visita nuovamente 
+					quel sito web.
+				</p>
+				
+				<p style="line-height: 100%;">
+					I nostri cookie ci aiutano a:
+				</p>
+				
+				<ul style="padding-left:30px; padding-right:10px;">
+					<li>Permettere al sito web di lavorare come atteso</li>
+					<li>Ricordare le impostazioni durante e tra le visite al sito</li>
+					<li>Migliorare la velocità / sicurezza del sito</li>
+					<li>Permette di condividere le pagine con i social network come Facebook</li>			
+				</ul>
+				
+				<p style="line-height: 100%;">
+					Non viene fatto uso di cookies per:
+				</p>
+						
+				<ul style="padding-left:30px; padding-right:10px;">
+					<li>Raccogliere tutte le informazioni di identificazione personale (senza il vostro consenso)</li>
+					<li>Raccogliere tutte le informazioni sensibili (senza il tuo esplicito consenso)</li>
+					<li>Passare i dati alle reti pubblicitarie</li>	
+				</ul>
+				<p style="line-height: 100%;">
+					Potete saperne di più su tutti i cookies che utilizziamo qui sotto.
+				</p>
+				
+				<p style="line-height: 100%;">
+					Se le impostazioni del software che si sta utilizzando per la navigazione del sito (il browser) sono regolati per accettare 
+					i cookies prendiamo questo, e l'uso continuato del nostro sito web, a significare che si acconsente all'utilizzo di cookies. 
+					Se si desidera rimuovere o non usare i cookies dal nostro sito lo si può fare seguendo le indicazioni riportate di seguito, 
+					così facendo tuttavia il nostro sito potrebbe non funzionare come ci si aspetterebbe.
+				</p>
+				
+				<h4 style="font-weight: bold;">I nostri Cookies</h4>
+			   
+				<p style="line-height: 100%;">
+					Utilizziamo i cookie per garantire determinate funzionalità del sito web tra cui:
+				</p>
+				
+				<ul style="padding-left:30px; padding-right:10px;">
+					<li>Operazioni di Login e successive autenticazioni</li>
+					<li>Autenticazione a servizi WMS, WFS, WPS attraverso richieste HTTP</li>	
+				</ul>
+				
+				<h4 style="font-weight: bold;">Social Website Cookies</h4>
+				<p style="line-height: 100%;">
+					Tu puoi facilmente esprimere il tuo gradimento o condividere alcuni contenuti su Facebook e Twitter (abbiamo incluso 
+					i pulsanti di condivisione sul nostro sito). I cookies sono stati abilitati per:
+				</p>
+				
+				<ul style="padding-left:30px; padding-right:10px;">
+					<li>Twitter</li>
+					<li>Facebook</li>	
+				</ul>
+				<p style="line-height: 100%;">
+					Le implicazioni di privacy su questo variano da social network a social network e dipenderanno dalle impostazioni di privacy 
+					che avete scelto su queste reti.
+				</p>
+				<h4 style="font-weight: bold;">Disabilitare i Cookies</h4>
+				
+				<p style="line-height: 100%;">
+					Di solito è possibile disattivare i cookies modificando le impostazioni del browser per impedire l'uso degli stessi (vedi 
+					<a href="http://www.attacat.co.uk/resources/cookies/how-to-ban" target="_blank">qui</a>). 
+					In questo modo però probabilmente si limiteranno le funzionalità del nostro come di molti dei siti web di tutto il mondo (i cookie 
+					sono una componente standard della maggior parte dei siti web moderni). 
+				</p>
+				
+				<br/><br/><br/>
+				
+			</div>
+		</div>
+	</div>
+	</body>
+</html>

--- a/mapcomposer/app/static/externals/cookiechoices/LICENSE
+++ b/mapcomposer/app/static/externals/cookiechoices/LICENSE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/mapcomposer/app/static/externals/cookiechoices/cookiechoices.css
+++ b/mapcomposer/app/static/externals/cookiechoices/cookiechoices.css
@@ -1,0 +1,51 @@
+#cookie-statement {
+    background-color: #5a5a5a;
+    
+
+    -moz-border-radius: 0;
+    -webkit-border-radius: 0;
+    border-radius: 0;
+    color: #fff;
+    display: none;
+    font-weight: bold;
+    margin: 0 -15px;
+    padding-left: 0;
+    padding-right: 0;
+    position: absolute;
+    width: 100%;
+    z-index: 999
+}
+
+#cookieChoiceInfo.display {
+    display: block
+}
+
+#cookieChoiceInfo .text {
+    padding: 0 15px;
+    display: block
+}
+
+#cookieChoiceInfo a {
+    background-color: #303030;
+    border: 1px solid rgba(0, 0, 0, .1);
+    -moz-border-radius: 2px;
+    -webkit-border-radius: 2px;
+    border-radius: 2px;
+    color: #fff;
+    cursor: pointer;
+    line-height: 19px;
+    padding: 4px 8px;
+    text-decoration: none;
+    white-space: nowrap
+}
+#cookieChoiceInfo, #cookieChoiceInfo div {
+    background-color: #5a5a5a;
+    opacity: .8;
+    color: #fff;
+    font-weight: bold;
+    min-height: 40px;
+    text-align: center;
+    padding-top: 15px;
+   
+}
+

--- a/mapcomposer/app/static/externals/cookiechoices/cookiechoices.js
+++ b/mapcomposer/app/static/externals/cookiechoices/cookiechoices.js
@@ -1,0 +1,171 @@
+/*
+ Copyright 2014 Google Inc. All rights reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+(function(window) {
+
+  if (!!window.cookieChoices) {
+    return window.cookieChoices;
+  }
+
+  var document = window.document;
+  // IE8 does not support textContent, so we should fallback to innerText.
+  var supportsTextContent = 'textContent' in document.body;
+
+  var cookieChoices = (function() {
+
+    var cookieName = 'displayCookieConsent';
+    var cookieConsentId = 'cookieChoiceInfo';
+    var dismissLinkId = 'cookieChoiceDismiss';
+
+    function _createHeaderElement(cookieText, dismissText, linkText, linkHref) {
+      var butterBarStyles = 'position:fixed;width:100%;' +
+          'margin:0; left:0; top:0;z-index:1000;text-align:center;';
+
+      var cookieConsentElement = document.createElement('div');
+      cookieConsentElement.id = cookieConsentId;
+      cookieConsentElement.style.cssText = butterBarStyles;
+      cookieConsentElement.appendChild(_createConsentText(cookieText));
+
+      if (!!linkText && !!linkHref) {
+        cookieConsentElement.appendChild(_createInformationLink(linkText, linkHref));
+      }
+      cookieConsentElement.appendChild(_createDismissLink(dismissText));
+      return cookieConsentElement;
+    }
+
+    function _createDialogElement(cookieText, dismissText, linkText, linkHref) {
+      var glassStyle = 'position:fixed;width:100%;height:100%;z-index:999;' +
+          'top:0;left:0;opacity:0.5;filter:alpha(opacity=50);' +
+          'background-color:#ccc;';
+      var dialogStyle = 'z-index:1000;position:fixed;left:50%;top:50%';
+      var contentStyle = 'position:relative;left:-50%;margin-top:-25%;' +
+          'background-color:#fff;padding:20px;box-shadow:4px 4px 25px #888;';
+
+      var cookieConsentElement = document.createElement('div');
+      cookieConsentElement.id = cookieConsentId;
+
+      var glassPanel = document.createElement('div');
+      glassPanel.style.cssText = glassStyle;
+
+      var content = document.createElement('div');
+      content.style.cssText = contentStyle;
+
+      var dialog = document.createElement('div');
+      dialog.style.cssText = dialogStyle;
+
+      var dismissLink = _createDismissLink(dismissText);
+      dismissLink.style.display = 'block';
+      dismissLink.style.textAlign = 'right';
+      dismissLink.style.marginTop = '8px';
+
+      content.appendChild(_createConsentText(cookieText));
+      if (!!linkText && !!linkHref) {
+        content.appendChild(_createInformationLink(linkText, linkHref));
+      }
+      content.appendChild(dismissLink);
+      dialog.appendChild(content);
+      cookieConsentElement.appendChild(glassPanel);
+      cookieConsentElement.appendChild(dialog);
+      return cookieConsentElement;
+    }
+
+    function _setElementText(element, text) {
+      if (supportsTextContent) {
+        element.textContent = text;
+      } else {
+        element.innerText = text;
+      }
+    }
+
+    function _createConsentText(cookieText) {
+      var consentText = document.createElement('span');
+      _setElementText(consentText, cookieText);
+      return consentText;
+    }
+
+    function _createDismissLink(dismissText) {
+      var dismissLink = document.createElement('a');
+      _setElementText(dismissLink, dismissText);
+      dismissLink.id = dismissLinkId;
+      dismissLink.href = '#';
+      dismissLink.style.marginLeft = '24px';
+      return dismissLink;
+    }
+
+    function _createInformationLink(linkText, linkHref) {
+      var infoLink = document.createElement('a');
+      _setElementText(infoLink, linkText);
+      infoLink.href = linkHref;
+      infoLink.target = '_blank';
+      infoLink.style.marginLeft = '8px';
+      return infoLink;
+    }
+
+    function _dismissLinkClick() {
+      _saveUserPreference();
+      _removeCookieConsent();
+      return false;
+    }
+
+    function _showCookieConsent(cookieText, dismissText, linkText, linkHref, isDialog) {
+      if (_shouldDisplayConsent()) {
+        _removeCookieConsent();
+        var consentElement = (isDialog) ?
+            _createDialogElement(cookieText, dismissText, linkText, linkHref) :
+            _createHeaderElement(cookieText, dismissText, linkText, linkHref);
+        var fragment = document.createDocumentFragment();
+        fragment.appendChild(consentElement);
+        document.body.appendChild(fragment.cloneNode(true));
+        document.getElementById(dismissLinkId).onclick = _dismissLinkClick;
+      }
+    }
+
+    function showCookieConsentBar(cookieText, dismissText, linkText, linkHref) {
+      _showCookieConsent(cookieText, dismissText, linkText, linkHref, false);
+    }
+
+    function showCookieConsentDialog(cookieText, dismissText, linkText, linkHref) {
+      _showCookieConsent(cookieText, dismissText, linkText, linkHref, true);
+    }
+
+    function _removeCookieConsent() {
+      var cookieChoiceElement = document.getElementById(cookieConsentId);
+      if (cookieChoiceElement != null) {
+        cookieChoiceElement.parentNode.removeChild(cookieChoiceElement);
+      }
+    }
+
+    function _saveUserPreference() {
+      // Set the cookie expiry to one year after today.
+      var expiryDate = new Date();
+      expiryDate.setFullYear(expiryDate.getFullYear() + 1);
+      document.cookie = cookieName + '=y; expires=' + expiryDate.toGMTString();
+    }
+
+    function _shouldDisplayConsent() {
+      // Display the header only if the cookie has not been set.
+      return !document.cookie.match(new RegExp(cookieName + '=([^;]+)'));
+    }
+
+    var exports = {};
+    exports.showCookieConsentBar = showCookieConsentBar;
+    exports.showCookieConsentDialog = showCookieConsentDialog;
+    return exports;
+  })();
+
+  window.cookieChoices = cookieChoices;
+  return cookieChoices;
+})(this);

--- a/mapcomposer/app/static/externals/mapmanager/translations/de.js
+++ b/mapcomposer/app/static/externals/mapmanager/translations/de.js
@@ -342,7 +342,7 @@ GeoExt.Lang.add("de", {
         "cookieText": "Cookies erleichtern die Bereitstellung unserer Dienste. Mit der Nutzung unserer Dienste erklären Sie sich damit einverstanden, dass wir Cookies verwenden.",
         "dismissText": "OK",
         "linkText":"Weitere Informationen",
-        "linkHref":"http://google.com"
+        "linkHref":"cookies-policy-en.html"
 
   }
 });

--- a/mapcomposer/app/static/externals/mapmanager/translations/de.js
+++ b/mapcomposer/app/static/externals/mapmanager/translations/de.js
@@ -337,5 +337,12 @@ GeoExt.Lang.add("de", {
         successText: "Erfolg",
         errorText:"Error",
         runSuccessText: "Der Arbeitsablauf wurde erfolgreich begonnen<br/>"
-    }
+    },
+    "cookieChoices": {
+        "cookieText": "Cookies erleichtern die Bereitstellung unserer Dienste. Mit der Nutzung unserer Dienste erklären Sie sich damit einverstanden, dass wir Cookies verwenden.",
+        "dismissText": "OK",
+        "linkText":"Weitere Informationen",
+        "linkHref":"http://google.com"
+
+  }
 });

--- a/mapcomposer/app/static/externals/mapmanager/translations/en.js
+++ b/mapcomposer/app/static/externals/mapmanager/translations/en.js
@@ -337,5 +337,11 @@ GeoExt.Lang.add("en", {
         successText: "Success",
         errorText:"Error",
         runSuccessText: "The workflow has been started successfully<br/>"
-    }
+    },
+    "cookieChoices": {
+        "cookieText": "Cookies help us deliver our services. By using our services, you agree to our use of cookies.",
+        "dismissText": "Got it",
+        "linkText":"Learn more",
+        "linkHref":"http://google.com"
+  }
 });

--- a/mapcomposer/app/static/externals/mapmanager/translations/en.js
+++ b/mapcomposer/app/static/externals/mapmanager/translations/en.js
@@ -340,8 +340,8 @@ GeoExt.Lang.add("en", {
     },
     "cookieChoices": {
         "cookieText": "Cookies help us deliver our services. By using our services, you agree to our use of cookies.",
-        "dismissText": "Got it",
+        "dismissText": "I Agree",
         "linkText":"Learn more",
-        "linkHref":"http://google.com"
+        "linkHref":"cookies-policy-en.html"
   }
 });

--- a/mapcomposer/app/static/externals/mapmanager/translations/es.js
+++ b/mapcomposer/app/static/externals/mapmanager/translations/es.js
@@ -337,5 +337,12 @@ GeoExt.Lang.add("es", {
         successText: "Éxito",
         errorText:"Error",
         runSuccessText: "El flujo de trabajo se ha iniciado con éxito<br/>"
-    }
+    }, 
+    "cookieChoices": {
+        "cookieText": "Las cookies nos ayudan a ofrecer nuestros servicios. Al utilizarlos, usted acepta el uso de cookies.",
+        "dismissText": "Entendido",
+        "linkText":"Más información",
+        "linkHref":"http://google.com"
+
+  } 
 });

--- a/mapcomposer/app/static/externals/mapmanager/translations/es.js
+++ b/mapcomposer/app/static/externals/mapmanager/translations/es.js
@@ -342,7 +342,7 @@ GeoExt.Lang.add("es", {
         "cookieText": "Las cookies nos ayudan a ofrecer nuestros servicios. Al utilizarlos, usted acepta el uso de cookies.",
         "dismissText": "Entendido",
         "linkText":"Más información",
-        "linkHref":"http://google.com"
+        "linkHref":"cookies-policy-en.html"
 
   } 
 });

--- a/mapcomposer/app/static/externals/mapmanager/translations/fr.js
+++ b/mapcomposer/app/static/externals/mapmanager/translations/fr.js
@@ -342,6 +342,6 @@ GeoExt.Lang.add("fr", {
         "cookieText": "Les cookies nous permettent de vous proposer nos services plus facilement. En utilisant nos services, vous nous donnez expressément votre accord pour exploiter ces cookies.",
         "dismissText": "OK",
         "linkText":"En Savoir plus",
-        "linkHref":"http://google.com"
+        "linkHref":"cookies-policy-en.html"
   }  
 });

--- a/mapcomposer/app/static/externals/mapmanager/translations/fr.js
+++ b/mapcomposer/app/static/externals/mapmanager/translations/fr.js
@@ -336,5 +336,12 @@ GeoExt.Lang.add("fr", {
         successText: "Succès",
         errorText:"Error",
         runSuccessText: "Le flux de travail a été lancé avec succès<br/>"
-    }
+    },
+      
+    "cookieChoices": {
+        "cookieText": "Les cookies nous permettent de vous proposer nos services plus facilement. En utilisant nos services, vous nous donnez expressément votre accord pour exploiter ces cookies.",
+        "dismissText": "OK",
+        "linkText":"En Savoir plus",
+        "linkHref":"http://google.com"
+  }  
 });

--- a/mapcomposer/app/static/externals/mapmanager/translations/it.js
+++ b/mapcomposer/app/static/externals/mapmanager/translations/it.js
@@ -336,5 +336,12 @@ GeoExt.Lang.add("it", {
         successText: "Successo",
         errorText:"Errore",
         runSuccessText: "Il flusso è stato avviato correttamente<br/>"
-    }
+    }, 
+        "cookieChoices": {
+        "cookieText": "I cookie ci aiutano ad erogare servizi di qualità. Utilizzando i nostri servizi, l'utente accetta le nostre modalità d'uso dei cookie.",
+        "dismissText": "Accetto",
+        "linkText":"Dettagli",
+        "linkHref":"http://google.com"
+
+  }
 });

--- a/mapcomposer/app/static/externals/mapmanager/translations/it.js
+++ b/mapcomposer/app/static/externals/mapmanager/translations/it.js
@@ -341,7 +341,7 @@ GeoExt.Lang.add("it", {
         "cookieText": "I cookie ci aiutano ad erogare servizi di qualità. Utilizzando i nostri servizi, l'utente accetta le nostre modalità d'uso dei cookie.",
         "dismissText": "Accetto",
         "linkText":"Dettagli",
-        "linkHref":"http://google.com"
+        "linkHref":"cookies-policy-it.html"
 
   }
 });

--- a/mapcomposer/app/static/translations/de.js
+++ b/mapcomposer/app/static/translations/de.js
@@ -1029,5 +1029,13 @@ GeoExt.Lang.add("de", {
 		showExecutionIdText: "Zeige ID",
 		processIdentifierText: "Kennzeichnung",
 		downloadIdTitle: "Download ID"
-    }
+    },
+
+    "cookieChoices": {
+        "cookieText": "Cookies erleichtern die Bereitstellung unserer Dienste. Mit der Nutzung unserer Dienste erklären Sie sich damit einverstanden, dass wir Cookies verwenden.",
+        "dismissText": "OK",
+        "linkText":"Weitere Informationen",
+        "linkHref":"http://google.com"
+
+  }
 });

--- a/mapcomposer/app/static/translations/de.js
+++ b/mapcomposer/app/static/translations/de.js
@@ -1035,7 +1035,7 @@ GeoExt.Lang.add("de", {
         "cookieText": "Cookies erleichtern die Bereitstellung unserer Dienste. Mit der Nutzung unserer Dienste erklären Sie sich damit einverstanden, dass wir Cookies verwenden.",
         "dismissText": "OK",
         "linkText":"Weitere Informationen",
-        "linkHref":"http://google.com"
+        "linkHref":"cookies-policy-en.html"
 
   }
 });

--- a/mapcomposer/app/static/translations/en.js
+++ b/mapcomposer/app/static/translations/en.js
@@ -1019,9 +1019,9 @@ GeoExt.Lang.add("en", {
     }, 
     "cookieChoices": {
         "cookieText": "Cookies help us deliver our services. By using our services, you agree to our use of cookies.",
-        "dismissText": "Got it",
+        "dismissText": "I Agree",
         "linkText":"Learn more",
-        "linkHref":"http://google.com"
+        "linkHref":"cookies-policy-en.html"
 
   }
 });

--- a/mapcomposer/app/static/translations/en.js
+++ b/mapcomposer/app/static/translations/en.js
@@ -1016,5 +1016,12 @@ GeoExt.Lang.add("en", {
 		showExecutionIdText: "Show Execution ID",	
 		processIdentifierText: "Identifier",	
 		downloadIdTitle: "Download ID"
-    }
+    }, 
+    "cookieChoices": {
+        "cookieText": "Cookies help us deliver our services. By using our services, you agree to our use of cookies.",
+        "dismissText": "Got it",
+        "linkText":"Learn more",
+        "linkHref":"http://google.com"
+
+  }
 });

--- a/mapcomposer/app/static/translations/es.js
+++ b/mapcomposer/app/static/translations/es.js
@@ -858,5 +858,12 @@ GeoExt.Lang.add("es", {
 	
 	"gxp.plugins.StaticPage.prototype": {
         tabTitle: "Página estática"
-    }  
+    }, 
+    "cookieChoices": {
+        "cookieText": "Las cookies nos ayudan a ofrecer nuestros servicios. Al utilizarlos, usted acepta el uso de cookies.",
+        "dismissText": "Entendido",
+        "linkText":"Más información",
+        "linkHref":"http://google.com"
+
+  }  
 });

--- a/mapcomposer/app/static/translations/es.js
+++ b/mapcomposer/app/static/translations/es.js
@@ -863,7 +863,7 @@ GeoExt.Lang.add("es", {
         "cookieText": "Las cookies nos ayudan a ofrecer nuestros servicios. Al utilizarlos, usted acepta el uso de cookies.",
         "dismissText": "Entendido",
         "linkText":"Más información",
-        "linkHref":"http://google.com"
+        "linkHref":"cookies-policy-en.html"
 
   }  
 });

--- a/mapcomposer/app/static/translations/fr.js
+++ b/mapcomposer/app/static/translations/fr.js
@@ -902,7 +902,14 @@ GeoExt.Lang.add("fr", {
 	
 	"gxp.plugins.StaticPage.prototype": {
         tabTitle: "Page Statique"
-    } 
+    } ,
+      
+    "cookieChoices": {
+        "cookieText": "Les cookies nous permettent de vous proposer nos services plus facilement. En utilisant nos services, vous nous donnez expressément votre accord pour exploiter ces cookies.",
+        "dismissText": "OK",
+        "linkText":"En Savoir plus",
+        "linkHref":"http://google.com"
+  }  
 });
 
 

--- a/mapcomposer/app/static/translations/fr.js
+++ b/mapcomposer/app/static/translations/fr.js
@@ -908,7 +908,7 @@ GeoExt.Lang.add("fr", {
         "cookieText": "Les cookies nous permettent de vous proposer nos services plus facilement. En utilisant nos services, vous nous donnez expressément votre accord pour exploiter ces cookies.",
         "dismissText": "OK",
         "linkText":"En Savoir plus",
-        "linkHref":"http://google.com"
+        "linkHref":"cookies-policy-en.html"
   }  
 });
 

--- a/mapcomposer/app/static/translations/it.js
+++ b/mapcomposer/app/static/translations/it.js
@@ -7,6 +7,7 @@
 */
 
 GeoExt.Lang.add("it", {
+
     "GeoExplorer.prototype": {
         zoomSliderText: "<div>Livello di Zoom: {zoom}</div><div>Scala: 1:{scale}</div>",
         loadConfigErrorText: "Impossibile leggere la configurazione salvata : <br />",
@@ -1030,5 +1031,13 @@ GeoExt.Lang.add("it", {
 		showExecutionIdText: "Mostra ID",
 		processIdentifierText: "Identificatore",
 		downloadIdTitle: "ID Download"
-    }
+    },
+    "cookieChoices": {
+        "cookieText": "I cookie ci aiutano ad erogare servizi di qualità. Utilizzando i nostri servizi, l'utente accetta le nostre modalità d'uso dei cookie.",
+        "dismissText": "Accetto",
+        "linkText":"Dettagli",
+        "linkHref":"http://google.com"
+
+  }
+
 });

--- a/mapcomposer/app/static/translations/it.js
+++ b/mapcomposer/app/static/translations/it.js
@@ -1036,7 +1036,7 @@ GeoExt.Lang.add("it", {
         "cookieText": "I cookie ci aiutano ad erogare servizi di qualità. Utilizzando i nostri servizi, l'utente accetta le nostre modalità d'uso dei cookie.",
         "dismissText": "Accetto",
         "linkText":"Dettagli",
-        "linkHref":"http://google.com"
+        "linkHref":"cookies-policy-it.html"
 
   }
 

--- a/mapcomposer/app/templates/base.html
+++ b/mapcomposer/app/templates/base.html
@@ -12,10 +12,13 @@
         <script type="text/javascript" src="externals/ext/adapter/ext/ext-base.js"></script>
         <script type="text/javascript" src="externals/ext/ext-all.js"></script>
 		
+         <link rel="stylesheet" type="text/css" href="externals/cookiechoices/cookiechoices.css">
+         
         <% render extrahead %>
     </head>
     <body>
         <% render content %>
 		<div style="position:absolute; top:-10000px; left:-10000px; visibility:hidden"><canvas id="printcanvas" /></div>
+         <script  type="text/javascript" src="script/cookiechoices.js"></script>
     </body>
 </html>

--- a/mapcomposer/app/templates/composer.html
+++ b/mapcomposer/app/templates/composer.html
@@ -555,7 +555,7 @@
 	    	/*Consent cookie text and link from transaltion files, google cookieChoices.js lib must be added to page's body*/
             if(serverConfig.cookieConsent && cookieChoices.cookieText && !parent.manager){
             cookieChoices.showCookieConsentBar(cookieChoices.cookieText,
-            cookieChoices.dismissText, (serverConfig.cookieConsent.link)?cookieChoices.linkText:null, cookieChoices.linkHref);
+            cookieChoices.dismissText, cookieChoices.linkText, cookieChoices.linkHref);
             };
 	    };
 

--- a/mapcomposer/app/templates/composer.html
+++ b/mapcomposer/app/templates/composer.html
@@ -552,6 +552,11 @@
 					resources
 				);
 			};
+	    	/*Consent cookie text and link from transaltion files, google cookieChoices.js lib must be added to page's body*/
+            if(serverConfig.cookieConsent && cookieChoices.cookieText && !parent.manager){
+            cookieChoices.showCookieConsentBar(cookieChoices.cookieText,
+            cookieChoices.dismissText, (serverConfig.cookieConsent.link)?cookieChoices.linkText:null, cookieChoices.linkHref);
+            };
 	    };
 
 	    // geostore base

--- a/mapcomposer/app/templates/manager.html
+++ b/mapcomposer/app/templates/manager.html
@@ -48,7 +48,7 @@
     <!-- common data  -->
     <script type="text/javascript" src="config/common/localConfig.js"></script>
     
-    
+    <link rel="stylesheet" type="text/css" href="externals/cookiechoices/cookiechoices.css">
 
     <script>
         // ///////////////////////////////////////////////////////////////
@@ -143,6 +143,12 @@
                     
                 }
             });
+           
+            /*Consent cookie text and link from transaltion files, google cookieChoices.js lib must be added to page's body*/
+            if(serverConfig.cookieConsent && cookieChoices.cookieText){
+            cookieChoices.showCookieConsentBar(cookieChoices.cookieText,
+            cookieChoices.dismissText, (serverConfig.cookieConsent.link)?cookieChoices.linkText:null, cookieChoices.linkHref);
+            }
         };
         
         Ext.Ajax.request({
@@ -205,6 +211,7 @@
     <body>
         <% render content %>
 		<div id="wrap" style="visibility:hidden"></div>
+        <script  type="text/javascript" src="script/cookiechoices.js"></script>
     </body>
 </html>
    

--- a/mapcomposer/app/templates/manager.html
+++ b/mapcomposer/app/templates/manager.html
@@ -147,7 +147,7 @@
             /*Consent cookie text and link from transaltion files, google cookieChoices.js lib must be added to page's body*/
             if(serverConfig.cookieConsent && cookieChoices.cookieText){
             cookieChoices.showCookieConsentBar(cookieChoices.cookieText,
-            cookieChoices.dismissText, (serverConfig.cookieConsent.link)?cookieChoices.linkText:null, cookieChoices.linkHref);
+            cookieChoices.dismissText, cookieChoices.linkText, cookieChoices.linkHref);
             }
         };
         

--- a/mapcomposer/app/templates/viewer.html
+++ b/mapcomposer/app/templates/viewer.html
@@ -1,16 +1,5 @@
-﻿<!DOCTYPE html>
-<html>
-    <head>
-        <!--meta http-equiv="X-UA-Compatible" content="IE=8" /-->
-        <title>Map Viewer</title>
-        <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
-        <link rel="shortcut icon" href="theme/app/img/favicon.ico">
-		
-        <!-- Ext resources -->
-        <link rel="stylesheet" type="text/css" href="externals/ext/resources/css/ext-all.css">
-        <link rel="stylesheet" type="text/css" href="externals/ext/resources/css/xtheme-gray.css">
-        <script type="text/javascript" src="externals/ext/adapter/ext/ext-base.js"></script>
-        <script type="text/javascript" src="externals/ext/ext-all.js"></script>
+<% extends ./base.html %>
+<% subskin extrahead %>
         
 		<!-- OpenLayers resources -->
         <link rel="stylesheet" type="text/css" href="externals/openlayers/theme/default/style.css">
@@ -411,6 +400,11 @@
 						resources
 					);
 				};
+            /*Consent cookie text and link from transaltion files, google cookieChoices.js lib must be added to page's body*/
+            if(serverConfig.cookieConsent && cookieChoices.cookieText){
+            cookieChoices.showCookieConsentBar(cookieChoices.cookieText,
+            cookieChoices.dismissText, (serverConfig.cookieConsent.link)?cookieChoices.linkText:null, cookieChoices.linkHref);
+            };
             };			
                 
 			Ext.Ajax.request({
@@ -451,9 +445,3 @@
 			});
         
     </script>
-    </head>
-    <body>
-        <% render content %>
-		<div style="position:absolute; top:-10000px; left:-10000px; visibility:hidden"><canvas id="printcanvas" /></div>
-    </body>
-</html>

--- a/mapcomposer/app/templates/viewer.html
+++ b/mapcomposer/app/templates/viewer.html
@@ -403,7 +403,7 @@
             /*Consent cookie text and link from transaltion files, google cookieChoices.js lib must be added to page's body*/
             if(serverConfig.cookieConsent && cookieChoices.cookieText){
             cookieChoices.showCookieConsentBar(cookieChoices.cookieText,
-            cookieChoices.dismissText, (serverConfig.cookieConsent.link)?cookieChoices.linkText:null, cookieChoices.linkHref);
+            cookieChoices.dismissText, cookieChoices.linkText, cookieChoices.linkHref);
             };
             };			
                 

--- a/mapcomposer/buildjs.cfg
+++ b/mapcomposer/buildjs.cfg
@@ -441,4 +441,8 @@ include =
 root = app/static/script/common
 include =
     data/GeoStoreStore.js
-    
+
+[cookiechoices.js]
+root = app/static/externals/cookiechoices
+include =
+    cookiechoices.js


### PR DESCRIPTION
To add cookies consent, just pass in configuration file 
"cookieConsent":{"link":true}.
If you like to skip link,  use "cookieConsent":true or "cookieConsent":{"link":false}.
To customize consent cookies text and link, change default values in mapmanager and geoexplorer translation  files.
System is based on https://www.cookiechoices.org/ library.