### PR TITLE
Close #514

### DIFF
--- a/mapcomposer/app/static/externals/mapmanager/src/mxp/plugins/UserManager.js
+++ b/mapcomposer/app/static/externals/mapmanager/src/mxp/plugins/UserManager.js
@@ -93,10 +93,20 @@ mxp.plugins.UserManager = Ext.extend(mxp.plugins.Tool, {
      */
     addOutput: function(config) {
 
+
+        var me=this;
         var login = this.target.login ? this.target.login: 
                 this.loginManager && this.target.currentTools[this.loginManager] 
                 ? this.target.currentTools[this.loginManager] : null;
         var auth = login.login && login.login.getAuthHeader ? login.login.getAuthHeader() : this.target.auth;
+        
+        //If autoopen is true but we aren't logged we have to wait for login
+        if(this.autoOpen==true && !auth){
+            login.on("login",function(){
+                me.addOutput(config);
+            })
+            return;
+        }
         // create a user manager panel
         var usermanager = {
             region:'center',


### PR DESCRIPTION
User Manager, require auth param to query geostore.
When autoOpen is true, addOutput function is called before auth param is available.
I added a check that wait for login event to be fired to execute UserManager.addOutput().
