### PR TITLE
Geostore LAYERS_SOURCE Resource

### DIFF
--- a/mapcomposer/app/applications/he/buildjs.cfg
+++ b/mapcomposer/app/applications/he/buildjs.cfg
@@ -59,11 +59,13 @@ include =
     widgets/ContractsByCategory.js
     widgets/grid/ContractExpirationsGrid.js
     widgets/grid/ScheduledCapacitiesGrid.js
+    widgets/form/UserGroupMultiSelect.js
     plugins/GCD.js
     plugins/CapacityData.js
     plugins/Shippers.js
     plugins/Statistics.js
     plugins/ResultsGrid.js
     plugins/EnableLabel.js
+    plugins/AddLayersGeoStore.js
     GCDViewer.js
     

--- a/mapcomposer/app/applications/he/static/config/login.js
+++ b/mapcomposer/app/applications/he/static/config/login.js
@@ -251,6 +251,11 @@
     "removeTools":["googleearth_plugin", "googleearth_separator"],
 	"customTools":[
 		{
+		   "ptype": "gxp_addlayersgeostore",
+		    "actionTarget": "tree.tbar",
+			"id": "addlayers"
+		},
+		{
 			"ptype": "gxp_embedmapdialog",
 			"actionTarget": {"target": "paneltbar", "index": 2},
 			"embeddedTemplateName": "viewer",

--- a/mapcomposer/app/applications/he/static/css/gcd.css
+++ b/mapcomposer/app/applications/he/static/css/gcd.css
@@ -140,3 +140,14 @@ span.icon_span{
     z-index : -1 !important;
     padding : 0px !important;
 }
+/* Background for items selected in multiselect */
+.ux-mselect-selected{
+    background-color: rgb(204, 204, 204);
+}
+/** NEEDED TO MAKE MULTISELECT SCROLL **/
+.ux-mselect{
+    overflow:auto;
+    background:white;
+    position:relative; /* for calculating scroll offsets */
+    zoom:1;
+ }

--- a/mapcomposer/app/applications/he/static/hetranslations/de.js
+++ b/mapcomposer/app/applications/he/static/hetranslations/de.js
@@ -1,0 +1,24 @@
+GeoExt.Lang.add("de", {
+	"gxp.plugins.he.AddLayersGeoStore.prototype": {
+        gsErrorTitle:"GeoStore Fehler",
+        gsInfoTitle:"GeoStore Info",
+        editServerText:"Redigieren",
+        editServerTooltip:"Redigieren Ausgewählten Server",
+        deleteServerText:"Löschen",
+        deleteServerTooltip:"Löschen Ausgewählten Server",
+        gsGetSourcesError:"Können Sie Schicht Quellen Benutzers abrufen.",
+        gsCreateSourceError:"Nicht in der Lage zu erstellen und zu speichern GeoStore Ressource.",
+        gsUpdateSourceError:"Können Sie GeoStore Ressource zu aktualisieren.",
+        gsSavePermissionsError:"Können Sie Berechtigungen für Ressourcen zu sparen.",
+        gsDeleteSourceError: "Können Sie GeoStore Ressource zu löschen.",
+        gsCreateCategoryInfo: "GeoStore Ressourcen Behinderte, nur Admin kann fehlende LAYERS_SOURCE Kategorie zu erstellen.",
+        gsCreateCategoryAlert:"Anwendung ist die Erstellung der Ressource LAYERS_SOURCE GeoStore.",
+        gsCreateCategoryError:"Können Sie GeoStore Kategorie zu erstellen. GeoStore Ressourcen deaktiviert.",
+        gsCategoryCheckError:"Unable to Kategorie LAYERS_SOURCE überprüfen. GeoStore Ressourcen deaktiviert."
+    },
+    "gxp.he.NewSourceWindowGeoStore":{
+        groupsLabel:"Gruppen",
+        gsErrorTitle:"GeoStore Fehler",
+        gsGetPermissionError:"Nicht in der Lage, die Ressourcenberechtigungen abrufen."
+    }
+});

--- a/mapcomposer/app/applications/he/static/hetranslations/en.js
+++ b/mapcomposer/app/applications/he/static/hetranslations/en.js
@@ -1,0 +1,24 @@
+GeoExt.Lang.add("en", {
+	"gxp.plugins.he.AddLayersGeoStore.prototype": {
+        gsErrorTitle:"GeoStore Error",
+        gsInfoTitle:"GeoStore Info",
+        editServerText:"Edit",
+        editServerTooltip:"Edit Selected Server",
+        deleteServerText:"Delete",
+        deleteServerTooltip:"Delete Selected Server",
+        gsGetSourcesError:"Unable to retrieve user's layer sources.",
+        gsCreateSourceError:"Unable to create and save GeoStore resource.",
+        gsUpdateSourceError:"Unable to update GeoStore resource.",
+        gsSavePermissionsError:"Unable to save resource permissions.",
+        gsDeleteSourceError: "Unable to delete GeoStore resource.",
+        gsCreateCategoryInfo: "GeoStore resources disabled, only Admin can create missing LAYERS_SOURCE CATEGORY.",
+        gsCreateCategoryAlert:"Application is creating  GeoStore's resource LAYERS_SOURCE.",
+        gsCreateCategoryError:"Unable to create GeoStore category. GeoStore resources disabled.",
+        gsCategoryCheckError:"Unable to check category LAYERS_SOURCE. GeoStore resources disabled."
+    },
+    "gxp.he.NewSourceWindowGeoStore":{
+        groupsLabel:"Groups",
+        gsErrorTitle:"Geostore Error",
+        gsGetPermissionError:"Unable to retrieve resource permissions."
+    }
+});

--- a/mapcomposer/app/applications/he/static/hetranslations/es.js
+++ b/mapcomposer/app/applications/he/static/hetranslations/es.js
@@ -1,0 +1,24 @@
+GeoExt.Lang.add("es", {
+	"gxp.plugins.he.AddLayersGeoStore.prototype": {
+        gsErrorTitle:"GeoStore Error",
+        gsInfoTitle:"GeoStore Info",
+        editServerText:"Editar",
+        editServerTooltip:"Editar Servidor Seleccionado",
+        deleteServerText:"Borrar",
+        deleteServerTooltip:"Borrar Servidor Seleccionado",
+        gsGetSourcesError:"No se puede recuperar las fuentes de la capa de usuario.",
+        gsCreateSourceError:"No se puede crear y guardar recursos GeoStore.",
+        gsUpdateSourceError:"No se puede actualizar recursos GeoStore.",
+        gsSavePermissionsError:"No se puede guardar permisos de recursos.",
+        gsDeleteSourceError: "No se puede eliminar de recursos GeoStore.",
+        gsCreateCategoryInfo: "Recursos GeoStore discapacitados, única administración pueden crear falta CATEGORÍA LAYERS_SOURCE.",
+        gsCreateCategoryAlert:"Aplicación está creando LAYERS_SOURCE recursos de GeoStore.",
+        gsCreateCategoryError:"No se puede crear la categoría GeoStore. Recursos GeoStore desactivados.",
+        gsCategoryCheckError:"No se puede comprobar la categoría LAYERS_SOURCE. Recursos GeoStore desactivados."
+    },
+    "gxp.he.NewSourceWindowGeoStore":{
+        groupsLabel:"Grupos",
+        gsErrorTitle:"Geostore Error",
+        gsGetPermissionError:"No se puede recuperar permisos de recursos."
+    }
+});

--- a/mapcomposer/app/applications/he/static/hetranslations/fr.js
+++ b/mapcomposer/app/applications/he/static/hetranslations/fr.js
@@ -1,0 +1,24 @@
+GeoExt.Lang.add("fr", {
+	"gxp.plugins.he.AddLayersGeoStore.prototype": {
+        gsErrorTitle:"GeoStore Erreur",
+        gsInfoTitle:"Geostore  Infos",
+        editServerText:"Modifier",
+        editServerTooltip:"Modifier Serveur Sélectionné",
+        deleteServerText:"Effacer",
+        deleteServerTooltip:"Effacer Serveur Sélectionné",
+        gsGetSourcesError:"Impossible de récupérer les sources de la couche de l'utilisateur.",
+        gsCreateSourceError:"Impossible de créer et sauvegarder des ressources GeoStore.",
+        gsUpdateSourceError:"Impossible de mettre à jour des ressources de GeoStore.",
+        gsSavePermissionsError:"Impossible d'enregistrer les autorisations de ressources.",
+        gsDeleteSourceError: "Impossible de supprimer ressource GeoStore.",
+        gsCreateCategoryInfo: "Ressources GeoStore désactivé, seul administrateur peut créer manquer LAYERS_SOURCE CATÉGORIE.",
+        gsCreateCategoryAlert:"Application crée la ressource LAYERS_SOURCE de GeoStore.",
+        gsCreateCategoryError:"Impossible de créer la catégorie de GeoStore. Ressources GeoStore désactivé.",
+        gsCategoryCheckError:"Impossible de vérifier la catégorie LAYERS_SOURCE. Ressources GeoStore désactivés."
+    },
+    "gxp.he.NewSourceWindowGeoStore":{
+        groupsLabel:"Groupes",
+        gsErrorTitle:"GeoStore Erreur",
+        gsGetPermissionError:"Impossible de récupérer les autorisations de ressources."
+    }
+});

--- a/mapcomposer/app/applications/he/static/hetranslations/it.js
+++ b/mapcomposer/app/applications/he/static/hetranslations/it.js
@@ -1,0 +1,24 @@
+    GeoExt.Lang.add("it", {
+        "gxp.plugins.he.AddLayersGeoStore.prototype": {
+            gsErrorTitle:"Errore Geostore",
+            gsInfoTitle:"Geostore Info",
+            editServerText:"Modifica",
+            editServerTooltip:"Modifica Server Selezionato",
+            deleteServerText:"Elimina",
+            deleteServerTooltip:"Elimina Server Selezionato",
+            gsGetSourcesError:"Impossibile recuperare sorgenti server dell'utente",
+            gsCreateSourceError:"Impossibile creare risorsa GeosStore.",
+            gsUpdateSourceError:"Impossibile aggiornare risorsa GeoStore.",
+            gsSavePermissionsError:"Impossibile salvare permessi risorsa GeoStore.",
+            gsDeleteSourceError: "Impossibile eliminare risorsa GeoStore.",
+            gsCreateCategoryInfo: "GeoStore disabilitato,solo Admin può creare la categoria LAYERS_SOURCE.",
+            gsCreateCategoryAlert:"L'applicazione sta creando  categoria LAYERS_SOURCE.",
+            gsCreateCategoryError:"Impossibile creare la categoria GeoStore. GeoStore disabilitato.",
+            gsCategoryCheckError:"Impossibile controllare esistenza della categoria LAYERS_SOURCE. GeoStore disablitato."
+        },
+        "gxp.he.NewSourceWindowGeoStore":{
+            groupsLabel:"Grouppi",
+            gsErrorTitle:"Errore Geostore",
+            gsGetPermissionError:"Impossibile recuperare permessi risorsa."
+        }
+    });

--- a/mapcomposer/app/applications/he/static/script/plugins/AddLayersGeoStore.js
+++ b/mapcomposer/app/applications/he/static/script/plugins/AddLayersGeoStore.js
@@ -1,0 +1,1053 @@
+/**
+ *  Copyright (C) 2007 - 2015 GeoSolutions S.A.S.
+ *  http://www.geo-solutions.it
+ *
+ *  GPLv3 + Classpath exception
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+/**
+ * @author Andrea Cappugi (kappu72@gmail.com)
+ */
+
+/**
+ * @requires widgets/GeoStoreNewSourceWindow.js
+ */
+
+/** api: (define)
+ *  module = gxp.plugins
+ *  class = CapacityData
+ */
+
+/** api: (extends)
+ *  plugins/AddLayers.js
+ */
+Ext.namespace("gxp.plugins.he");
+
+/** api: constructor
+ *  .. class:: AddLayers(config)
+ *
+ *    Plugin for removing a selected layer from the map.
+ *    TODO Make this plural - selected layers
+ */
+gxp.plugins.he.AddLayersGeoStore = Ext.extend(gxp.plugins.AddLayers, {
+    
+    /** api: ptype = gxp_addlayersgeostore */
+    ptype: "gxp_addlayersgeostore",
+
+    /** api: config[gsErrorTitle]
+     *  ``String``
+     *  Error message title!
+     */
+    gsErrorTitle:"Geostore Error",
+
+    /** api: config[gsInfoTitle]
+     *  ``String``
+     *  Info message title!
+     */
+    gsInfoTitle:"Geostore Info",
+     
+    /** api: config[editServerText]
+     *  ``String``
+     *  Edit selected server button text
+     */
+    editServerText:"Edit",
+
+    /** api: config[editServerTooltip]
+     *  ``String``
+     *  Edit selected server button tooltip
+     */
+    editServerTooltip:"Edit Selected Server",
+
+    /** api: config[deleteServerText]
+     *  ``String``
+     *  Delete selected server button tooltip
+     */
+    deleteServerText:"Delete",
+    
+    /** api: config[deleteServerTooltip]
+     *  ``String``
+     *  Delete selected server button tooltip
+     */
+    deleteServerTooltip:"Delete Selected Server",
+
+    /** api: config[gsGetSourcesError]
+     *  ``String``
+     *  Error message for error in geostore get resources
+     */
+    gsGetSourcesError:"Unable to retrieve user's layer sources!",
+
+    /** api: config[gsCreateSourceError]
+     *  ``String``
+     *  Error message for error creating geostore resource
+     */
+    gsCreateSourceError:"Unable to create and save geostore resource",
+
+    /** api: config[gsUpdateSourceError]
+     *  ``String``
+     *  Error message for error updating geostore resource
+     */
+    gsUpdateSourceError:"Unable to update geostore resource",
+
+    /** api: config[gsSavePermissionsError]
+     *  ``String``
+     *  Error message for error saving geostore permissions
+     */
+    gsSavePermissionsError:"Unable to save resource permissions!",
+
+    /** api: config[gsDeleteSourceError]
+     *  ``String``
+     *  Error message for error deleting geostore resource
+     */
+    gsDeleteSourceError: "Unable to delete geostore resource!",
+    
+    /** api: config[gsCreateCategoryInfo]
+     *  ``String``
+     *  Info message, only roleAdmin can create needed geostore resource category 
+     */
+    gsCreateCategoryInfo: "GeoStore resources disabled, only Admin can create missing LAYERS_SOURCE CATEGORY",
+    
+    /** api: config[gsCreateCategoryAlert]
+     *  ``String``
+     *  Alert message, advise admin about geostore category creation
+     */
+    gsCreateCategoryAlert:"Application is creating  GeoStore's resource LAYERS_SOURCE",
+    
+    /** api: config[gsCreateCategoryError]
+     *  ``String``
+     *  Error message for error creating geostore category
+     */
+    gsCreateCategoryError:"Unable to create geostore category. GeoStore resources disabled!",
+    
+    /** api: config[gsCategoryCheckError]
+     *  ``String``
+     *  Error message for error creating geostore category
+     */
+    gsCategoryCheckError:"Unable to check category LAYERS_SOURCE. GeoStore resources disabled",
+    
+    /** private: property[geostoreSource]
+     *  boolena if true geostore source enabled
+     */
+    geostoreSource:false,
+
+    /** private: property[roleAdmin]
+     *  boolena if true user is Admin
+     */
+    roleAdmin:false,
+
+    /** private: property[advancedUser]
+     *  boolena if true user is Advanced User
+     */
+    advancedUser:false,
+
+     
+    /** api: method[addActions]
+     */
+    addActions: function() {
+        var selectedLayer;        
+        var actions = gxp.plugins.AddLayers.superclass.addActions.apply(this, [{
+            tooltip : this.addActionTip,
+            text: this.addActionText,
+            menuText: this.addActionMenuText,
+            disabled: true,
+            hidden: this.hideByDefault,
+            iconCls: "gxp-icon-addlayers",
+            handler : this.showCapabilitiesGrid,
+            scope: this
+        }]);
+        
+        this.target.on("ready", function() {
+            this.roleAdmin=(this.target && this.target.userDetails && this.target.userDetails.user.role == "ADMIN");
+            this.advancedUser=this.hasGroup(this.target.userDetails.user,'Advanced_Users');
+            this.checkLayerSourceCategory();
+        },this);
+        return actions;
+    },
+
+    /** api: method[showCapabilitiesGrid]
+     * Shows the window with a capabilities grid.
+     */
+    showCapabilitiesGrid: function() {
+        if(!this.capGrid) {
+            this.initCapGrid();
+        }
+        
+        this.capGrid.show();
+    },
+
+     /**
+     * private: method[initCapGrid]
+     * Constructs a window with a capabilities grid.
+     */
+    initCapGrid: function() {
+        var source, data = [];        
+        for (var id in this.target.layerSources) {
+            source = this.target.layerSources[id];
+            if (source.store) {
+                
+                var gsGroup=(source.gs_group)?source.gs_group:'Public';
+                data.push([id, gsGroup,source.title || id]);                
+            }
+        }
+        
+        var sources = new Ext.data.ArrayStore({
+            fields: ["id","gs_group","title"],
+            data: data
+        });
+        sources.sort('gs_group');
+        var expander = this.createExpander();
+        
+        var addLayers = function() {
+            
+            var apptarget = this.target;
+           // var locCode= GeoExt.Lang.locale;
+            var key = this.sourceComboBox.getValue();
+            var layerStore = this.target.mapPanel.layers;
+            var source = this.target.layerSources[key];
+            var records = capGridPanel.getSelectionModel().getSelections();
+            var record;
+            var defaultProps;
+
+            for (var i=0, ii=records.length; i<ii; ++i) {
+                
+                defaultProps = {
+                    name: records[i].get("name"),
+                    title: records[i].get("title"),
+                    source: key
+                };
+
+                record = source.createLayerRecord(defaultProps); 
+                  
+                if (record) {
+                    if (record.get("group") === "background") {
+                        layerStore.insert(0, [record]);
+                    } else {
+                        layerStore.add([record]);
+
+                        if(records.length == 1){
+                            var layer = record.get('layer');
+                            var extent = layer.restrictedExtent || layer.maxExtent || this.target.mapPanel.map.maxExtent;
+                            var map = this.target.mapPanel.map;
+
+                            // respect map properties
+                            var restricted = map.restrictedExtent || map.maxExtent;
+                            if (restricted) {
+                                extent = new OpenLayers.Bounds(
+                                    Math.max(extent.left, restricted.left),
+                                    Math.max(extent.bottom, restricted.bottom),
+                                    Math.min(extent.right, restricted.right),
+                                    Math.min(extent.top, restricted.top)
+                                );
+                            }
+
+                            map.zoomToExtent(extent, true);
+                        }
+                    }
+                }
+            }
+            
+            apptarget.modified = true;
+        };
+
+        var idx = 0;
+        if (this.startSourceId !== null) {
+            sources.each(function(record) {
+                if (record.get("id") === this.startSourceId) {
+                    idx = sources.indexOf(record);
+                }
+            }, this);
+        }
+
+        var capGridPanel = new Ext.grid.GridPanel({
+            store: this.target.layerSources[data[idx][0]].store,
+            autoScroll: true,
+            flex: 1,
+            autoExpandColumn: "title",
+            plugins: [expander],
+            colModel: new Ext.grid.ColumnModel([
+                expander,
+                {id: "title", header: this.panelTitleText, dataIndex: "title", sortable: true},
+                {header: "Id", dataIndex: "name", width: 150, sortable: true},
+                {header: "uuid", dataIndex: "keywords", width: 150, sortable: true, hidden: true}
+            ]),
+            listeners: {
+                rowdblclick: addLayers,
+                scope: this
+            }
+        });
+        
+        this.sourceComboBox = new Ext.form.ComboBox({
+            store: sources,
+            valueField: "id",
+            displayField: "title",
+            triggerAction: "all",
+            editable: false,
+            allowBlank: false,
+            forceSelection: true,
+            mode: "local",
+            value: data[idx][0],
+            tpl: new Ext.XTemplate(
+                '<tpl for=".">',
+                '<tpl if="this.gs_group != values.gs_group">',
+                '<tpl exec="this.gs_group = values.gs_group"></tpl>',
+                '<h1><span style="color:gray">{gs_group}</span></h1>',
+                '</tpl>',
+                '<div class="x-combo-list-item">{title}</div>',
+                '</tpl>'
+            ),
+            listeners: {
+                select: function(combo, record, index) {
+                    var source = this.target.layerSources[record.get("id")];
+                    
+                    capGridPanel.store.clearFilter();                    
+                    capGridPanel.reconfigure(source.store, capGridPanel.getColumnModel());
+                    // TODO: remove the following when this Ext issue is addressed
+                    // http://www.extjs.com/forum/showthread.php?100345-GridPanel-reconfigure-should-refocus-view-to-correct-scroller-height&p=471843
+                    capGridPanel.getView().focusRow(0);
+                    this.setSelectedSource(source);
+                    
+                    filterText.reset();
+                    
+                    // Enable or disable the source edit button only owner could edit and delete resources
+                    this.toolBarManager(source);            
+                },
+                scope: this
+            }
+        });
+        
+        var capGridToolbar = null;
+        if (this.target.proxy || data.length > 1) {
+            capGridToolbar = [
+                new Ext.Toolbar.TextItem({
+                    text: this.layerSelectionText
+                }),
+                this.sourceComboBox
+            ];
+        }
+        
+        if (this.target.proxy) {
+            capGridToolbar.push("-", new Ext.Button({
+                text: this.addServerText,
+                iconCls: "gxp-icon-addserver",
+                handler: function() {
+                    newSourceWindow.showWindow();   
+                }
+            }));
+            
+            capGridToolbar.push(new Ext.Button({
+                text: this.editServerText,
+                tooltip: this.editServerTooltip,
+                iconCls: "edit",
+                name: "edit_button",
+                disabled: true,
+                scope: this,
+                handler: function() {
+                    newSourceWindow.bindSource(this.selectedSource);
+                }
+            }));
+            
+            capGridToolbar.push(new Ext.Button({
+                text: this.deleteServerText,
+                tooltip: this.deleteServerTooltip,
+                iconCls: "delete",
+                scope: this,
+                handler: function() {               
+                    var removeFunction = function(buttonId, text, opt){        
+                        if(buttonId === 'ok'){          
+                            // /////////////////////////////////////////////////////
+                            // Remove the layers associated to the selected source
+                            // /////////////////////////////////////////////////////
+                            var layers = this.target.mapPanel.layers;
+
+                            var selSources = this.selectedSource;
+                            // /////////////////////////////////////////////////////
+                            // Check if the layer is the current selected BG 
+                            // in the map (if yes the source should not be removed).
+                            // /////////////////////////////////////////////////////
+                            var remove = true;
+                            layers.data.each(function(record, index, totalItems ) {
+                                var group = record.get('group');
+                                var name = record.get('name');
+                                var source = record.get('source');
+
+                                if(name && source == selSources.id && group == 'background'){
+                                    var visible = record.data.layer.visibility;
+                                    if(visible === true){
+                                        remove = false;
+                                    }                               
+                                }
+                            });             
+                        
+                            // ///////////////////////////
+                            // Remove the selected source
+                            // ///////////////////////////
+                            if(remove === true){
+                                // ////////////////////////////////////////////////////////////
+                                // Remove the source layers only if the source can be removed.
+                                // ////////////////////////////////////////////////////////////
+                                layers.data.each(function(record, index, totalItems ) {
+                                    var group = record.get('group');
+                                    var name = record.get('name');
+                                    var source = record.get('source');
+
+                                    if(name && source == selSources.id){
+                                        layers.remove(record);                              
+                                    }
+                                });
+                                if((selSources.owner==this.target.userDetails.user.name || this.roleAdmin ) && selSources.gsId) 
+                                    this.deleteLayersSource(selSources.gsId);
+                                
+                                var sourceRecordIdx = sources.find("id", selSources.id);
+                                var sourceRecord = sources.getAt(sourceRecordIdx);
+                                delete this.target.layerSources[sourceRecord.get("id")];
+                                sources.remove(sourceRecord);               
+                                
+                                var sourcesCount = sources.getCount();
+                                if(sourcesCount > 0){
+                                    this.sourceComboBox.onSelect(sources.getAt(0), 0);
+                                }else{
+                                    this.sourceComboBox.clearValue();
+                                    var capGridStore = capGridPanel.getStore();
+                                    capGridStore.removeAll();
+                                }                           
+                                
+                                this.target.modified = true;
+
+                            }else{
+                                Ext.Msg.show({
+                                   title: this.deleteSourceDialogTitle,
+                                   msg: this.deleteSourceText,
+                                   buttons: Ext.Msg.OK,
+                                   icon: Ext.MessageBox.WARNING,
+                                   scope: this
+                                });
+                            }
+                        }
+                    }
+                    
+                    Ext.Msg.show({
+                       title: this.deleteSourceDialogTitle,
+                       msg: this.deleteSourceDialogMsg,
+                       buttons: Ext.Msg.OKCANCEL,
+                       fn: removeFunction,
+                       icon: Ext.MessageBox.QUESTION,
+                       scope: this
+                    });
+                }
+            }));
+        }
+        
+        for(var count = 0, l = this.additionalSources.length; count < l; count++) {
+            this.availableSources.push(this.additionalSources[count]);
+        }
+        var newSourceWindow = new gxp.he.NewSourceWindowGeoStore({
+            modal: true,
+            auth:this.getAuth(),
+            target:this.target,
+            defaultVendor: this.defaultVendor,
+            availableSources: this.availableSources,
+            availableVendorOptions: this.availableVendorOptions,
+            availableFormats: this.availableFormats,
+            listeners: {
+                scope: this,
+                "server-added": function(url, type, sourceCfg,groups) {
+                    newSourceWindow.setLoading();
+                    var sourceCfg;
+                    for(var count = 0, l = this.availableSources.length; count < l; count++) {
+                        var currentSource = this.availableSources[count];
+                        if(currentSource.name === type) {
+                            //That was a bug, overraiding default obj modified
+                            sourceCfg = Ext.apply({}, sourceCfg,currentSource.config);
+                        }
+                    }
+
+                    var permissionsCfg=(groups)? groups.split(','):null;
+                    //Try to add source
+                    this.target.addLayerSource({
+                        config: sourceCfg,
+                        callback: function(id) {
+                            //Check if is edit case
+                            var idx = sources.find("id",  id);
+                            if(idx < 0){
+                                this.createLayerSource(sourceCfg,permissionsCfg,id);
+                            }
+                        },
+                        fallback: function(source, msg) {
+                            newSourceWindow.setError(
+                                new Ext.Template(this.addLayerSourceErrorText).apply({type: type, msg: msg})
+                            );
+                        },
+                        scope: this
+                    });
+                },
+                "server-modified": function(url, type, sourceCfg, sourceId,groups) {
+                    newSourceWindow.setLoading();
+
+                    var sourceRecordIdx = sources.find("id", sourceId);
+                    if(sourceRecordIdx >= 0){
+                        // The record of the combo box store
+                        var sourceRecord = sources.getAt(sourceRecordIdx);  
+                        var title = sourceRecord.get("title");
+                        if(sourceCfg.title != title){
+                            sourceRecord.set("title", sourceCfg.title);
+                            this.getSourceComboBox().setValue( sourceCfg.title );
+                        }                   
+                        
+                        // The record of the real used sources store
+                        var source = this.target.layerSources[sourceId];
+                        
+                        Ext.apply(source.initialConfig, sourceCfg);
+                        Ext.apply(source, sourceCfg);
+                        
+                        if(source.store.baseParams.VERSION != sourceCfg.version){
+                            source.store.baseParams.VERSION = sourceCfg.version;
+                            
+                            // //////////////////////////////
+                            // Check also the authparam
+                            // TODO: More checks on this
+                            // //////////////////////////////
+                            if(source.authParam != sourceCfg.authParam){
+                                if(source.authParam){
+                                    delete source.store.baseParams[source.authParam];
+                                }
+                                
+                                source.store.baseParams[sourceCfg.authParam] = source.getAuthParam();
+                            }
+                        }
+                        var permissionsCfg=(groups)? groups.split(','):null;
+
+                        source.on("ready", function(){
+                            if(source.gsId)this.updateLayerSource(source.initialConfig,permissionsCfg,source.gsId,source.gsName);
+                        },this);
+                        source.on("failure", function(){
+                            newSourceWindow.hide();
+                        });                     
+                        
+                        source.store.reload();
+                        this.target.modified = true;
+                    }
+                }
+            }
+        });
+        
+        var items = {
+            xtype: "container",
+            region: "center",
+            layout: "fit",
+            items: [capGridPanel]
+        };
+        
+        if (this.instructionsText) {
+            items.items.push({
+                xtype: "box",
+                autoHeight: true,
+                autoEl: {
+                    tag: "p",
+                    cls: "x-form-item",
+                    style: "padding-left: 5px; padding-right: 5px"
+                },
+                html: this.instructionsText
+            });
+        }
+        
+        var filterText =  new Ext.form.TextField({
+            emptyText : this.filterEmptyText,
+            width : 60,
+            enableKeyEvents : true,
+            listeners : {
+                keyup : function(form){
+                    var val = form.getRawValue().trim().toLowerCase();
+                    if(val){
+                        this.store.filterBy(function(rec, recId){
+                            var title = rec.get("title").trim().toLowerCase();
+                            if(title.indexOf(val) > -1){
+                                return true;
+                            } else {
+                                return false;
+                            }
+                        });                   
+                    } else {
+                        this.store.clearFilter();
+                    }
+                },
+                scope : capGridPanel
+            }
+        });
+        
+        var bbarItems = [
+            filterText,
+            new Ext.Button({
+                text: this.removeFilterText,
+                handler : function(button){
+                    this.store.clearFilter();
+                    filterText.reset();
+                },
+                iconCls: "gxp-icon-removefilter",
+                scope : capGridPanel
+            }),            
+            "->",
+            new Ext.Button({
+                text: this.addButtonText,
+                iconCls: "gxp-icon-addlayers",
+                handler: addLayers,
+                scope : this
+            }),
+            new Ext.Button({
+                text: this.doneText,
+                iconCls: "save",
+                handler: function() {
+                    this.capGrid.hide();
+                },
+                scope: this
+            })
+        ];
+        
+        var uploadButton = this.createUploadButton();
+        if (uploadButton) {
+            bbarItems.unshift(uploadButton);
+        }
+
+        //TODO use addOutput here instead of just applying outputConfig
+        this.capGrid = new Ext.Window(Ext.apply({
+            title: this.availableLayersText,
+            closeAction: "hide",
+            layout: "fit",
+            height: 300,
+            width: 580,
+            modal: true,
+            items: items,
+            tbar: capGridToolbar,
+            bbar: bbarItems,
+            listeners: {
+                hide: function(win) {
+                    capGridPanel.getSelectionModel().clearSelections();
+                },
+                show: function(win) {
+                    if(!this.selectedSource){
+                        this.setSelectedSource(this.target.layerSources[data[idx][0]]);
+                        this.toolBarManager(this.selectedSource);
+                    }
+                },
+                scope: this
+            }
+        }, this.initialConfig.outputConfig));
+        this.newSourceWindow=newSourceWindow;
+        
+    },
+    /** private: method[getUserLayersSources]
+     *  ``Function``Get  ueser LAYERS_RESOURCE resources from geostore
+     *
+     */
+    getUserLayersSources:function(){
+        var filter="<AND><CATEGORY><operator>EQUAL_TO</operator><name>LAYERS_SOURCE</name></CATEGORY></AND>"
+        Ext.Ajax.request({
+           url: this.target.geoStoreBaseURL+'resources/search/list?includeData=true&includeAttributes=true',
+           method: 'POST',
+           headers:{
+              'Content-Type' : 'text/xml',
+              'Accept' : 'application/json, text/plain, text/xml',
+              'Authorization' : this.getAuth()
+           },
+           params: filter,
+           scope: this,
+           success: function(response, opts){
+               var layersSourceList= Ext.util.JSON.decode(response.responseText).ResourceList;
+               var resources=[];
+
+               if(layersSourceList && layersSourceList.Resource){
+                   if(layersSourceList.Resource instanceof Array)resources=layersSourceList.Resource;
+                    else resources.push(layersSourceList.Resource);
+                    var sourceCount=resources.length;
+                   for(var i=0;i< resources.length;i++ ){
+                        var source=resources[i];
+                        if(source.data){
+                            var layersSource=Ext.util.JSON.decode(source.data.data);
+                                layersSource.gsId=source.id;
+                                layersSource.gsName=source.name;
+                                if(source.Attributes) layersSource.owner=this.getOwner(source.Attributes);  
+                                layersSource.gs_group=(layersSource.owner==this.target.userDetails.user.name)?'Personal':'Public';                     
+                                this.target.addLayerSource({
+                                    config: layersSource,
+                                    callback: function(id) {
+                                        sourceCount--;
+                                        if(sourceCount==0)this.actions[0].enable();
+                                },
+                                    fallback: function(source, msg) {
+                                        sourceCount--;
+                                        if(sourceCount==0)this.actions[0].enable();
+                                },
+                                scope: this
+                            });
+                        }
+                   }
+
+
+               }else this.actions[0].enable();
+           },
+           failure:  function(response, opts){
+                Ext.Msg.show({
+                 title: this.gsErrorTitle,
+                 msg: this.gsGetSourcesError+this.getErrorMsg(response),
+                 buttons: Ext.Msg.OK,
+                 icon: Ext.MessageBox.ERROR
+              });
+             this.actions[0].enable();   
+           }
+        }); 
+
+    },
+
+    /** private: method[createLayerSource]
+     *  ``Function``Create a new LAYERS_RESOURCE resource and save on geostore
+     *
+     */
+    createLayerSource: function(sourceCfg,permissionsCfg,sourceId){
+        var owner =this.target.userDetails.user.name;
+        var resourceName=owner+this.generateUUID();
+        var lSourceResource="<Resource><Attributes><attribute><name>owner</name><type>STRING</type><value>"+
+        owner+"</value></attribute></Attributes><description></description><metadata></metadata>"+
+        "<name>"+resourceName+"</name><category><name>LAYERS_SOURCE</name></category><store><data>"+
+        "<![CDATA[ "+Ext.util.JSON.encode(sourceCfg)+" ]]></data></store></Resource>";
+
+        Ext.Ajax.request({
+           url: this.target.geoStoreBaseURL+'resources',
+           method: 'POST',
+           headers:{
+              'Content-Type' : 'text/xml',
+              'Accept' : 'application/json, text/plain, text/xml',
+              'Authorization' : this.getAuth()
+           },
+           params: lSourceResource,
+           scope: this,
+           success: function(response, opts){              
+            //CREATE GEOSTORE PERMISSIONS
+            if(permissionsCfg)   
+                this.createLayerSourcePermissions(response.responseText,permissionsCfg);
+            //ADD TO COMBOBOX!
+            var sources=this.getSourceComboBox().getStore();
+            var source=this.target.layerSources[sourceId];
+            source.owner=owner;
+            source.gsId=Number(response.responseText);
+            source.gsName=resourceName;
+            source.gs_group='Personal';
+            var record = new sources.recordType({
+                id: sourceId,
+                gs_group:'Personal',
+                title: this.target.layerSources[sourceId].title || this.untitledText
+                });
+            sources.insert(this.getPersonalInsertIdx(),[record]);
+            this.sourceComboBox.onSelect(record, sources.getTotalCount()-1);
+            this.target.modified = true;
+            this.newSourceWindow.hide();
+           },
+           failure:  function(response, opts){
+             //REMOVE SOURCE FORM LAYERS SOURCES
+            delete this.target.layerSources[sourceId];
+            this.newSourceWindow.hide();              
+            Ext.Msg.show({
+                         title: this.gsErrorTitle,
+                         msg: this.gsCreateSourceError+this.getErrorMsg(response),
+                         buttons: Ext.Msg.OK,
+                         icon: Ext.MessageBox.ERROR
+                      });
+           }
+        }); 
+
+    },
+    /** private: method[updateLayerSource]
+     *  ``Function``Update LAYERS_RESOURCE resource on geostore
+     *
+     */
+    updateLayerSource: function(sourceCfg,permissionsCfg,rId,name){
+        var lSourceResource="<Resource><description></description><metadata></metadata>"+
+        "<name>"+name+"</name><category><name>LAYERS_SOURCE</name></category><store><data>"+
+        "<![CDATA[ "+Ext.util.JSON.encode(sourceCfg)+" ]]></data></store></Resource>";
+        lSourceResource=Ext.util.JSON.encode(sourceCfg);
+        Ext.Ajax.request({
+           url: this.target.geoStoreBaseURL+'data/'+rId,
+           method: 'PUT',
+           headers:{
+              'Content-Type' : 'text/xml',
+              'Accept' : 'application/json, text/plain, text/xml',
+              'Authorization' : this.getAuth()
+           },
+           params: lSourceResource,
+           scope: this,
+           success: function(response, opts){              
+            //DEVI SETTARE I PERMESSI 
+            if(permissionsCfg)   
+                this.createLayerSourcePermissions(response.responseText,permissionsCfg);
+            this.newSourceWindow.hide();
+            //this.getSourceComboBox.doLayout();
+           },
+           failure:  function(response, opts){
+            this.newSourceWindow.hide();
+                Ext.Msg.show({
+                         title:this.gsErrorTitle,
+                         msg: this.gsUpdateSourceError+this.getErrorMsg(response),
+                         buttons: Ext.Msg.OK,
+                         icon: Ext.MessageBox.ERROR
+                      });
+
+
+           }
+        }); 
+
+    },
+    /** private: method[createLayerSourcePermissions]
+     *  ``Function``SET Geostore resource's permissions
+     *
+     */
+    createLayerSourcePermissions: function(response,permissionsCfg){
+        var xml = '<SecurityRuleList>';
+           for(var i = 0; i < permissionsCfg.length; i++){
+                var gid=permissionsCfg[i];
+                xml += '<SecurityRule>' +'<canRead>true</canRead><canWrite>false</canWrite>';
+                xml += '<group><id>' + gid + '</id></group></SecurityRule>';
+            }
+             xml += '</SecurityRuleList>';
+           
+        Ext.Ajax.request({
+           url: this.target.geoStoreBaseURL+'resources/resource/'+response+'/permissions',
+           method: 'POST',
+           headers:{
+              'Content-Type' : 'text/xml',
+              'Accept' : 'application/json, text/plain, text/xml',
+              'Authorization' : this.getAuth()
+           },
+           params: xml,
+           scope: this,
+           success: function(response, opts){
+               
+           },
+           failure:  function(response, opts){
+              Ext.Msg.show({
+                         title: this.gsErrorTitle,
+                         msg: this.gsSavePermissionsError+this.getErrorMsg(response),
+                         buttons: Ext.Msg.OK,
+                         icon: Ext.MessageBox.ERROR
+                      });   
+           }
+        }); 
+    },
+    /** private: method[deleteLayersSource]
+     *  ``Function``Delete Geostore LAYERS_SOURCE resource 
+     *
+     */
+    deleteLayersSource:function(rId){
+
+        Ext.Ajax.request({
+           url: this.target.geoStoreBaseURL+'resources/resource/'+rId,
+           method: 'DELETE',
+           headers:{
+              'Content-Type' : 'text/xml',
+              'Accept' : 'application/json, text/plain, text/xml',
+              'Authorization' : this.getAuth()
+           },
+           scope: this,
+           success: function(response, opts){
+              
+           },
+           failure:  function(response, opts){
+                 Ext.Msg.show({
+                         title: this.gsErrorTitle,
+                         msg: this.gsDeleteSourceError+this.getErrorMsg(response),
+                         buttons: Ext.Msg.OK,
+                         icon: Ext.MessageBox.ERROR
+                      });
+           }
+        }); 
+
+    },
+    /** private: method[createLayerSourceCategory]
+     *  ``Function``If dosnt' exist, create GeoStore LAYERS_SOURCE CATEGORY
+     *
+     */
+    createLayerSourceCategory:function(){
+        //Check user, only admin can create resorces
+        if(this.target.userDetails.user.role != "ADMIN"){
+            Ext.Msg.show({
+                 title:this.gsErrorTitle,
+                 msg: this.gsCreateCategoryInfo,
+                 buttons: Ext.Msg.OK,
+                 icon: Ext.MessageBox.ERROR
+              });
+        }
+        else{
+
+            Ext.Msg.show({
+                       title: this.gsInfoTitle,
+                       msg: this.gsCreateCategoryAlert,
+                       buttons: Ext.Msg.OK,
+                       fn: function(){
+                         var xml="<Category><name>LAYERS_SOURCE</name></Category>";
+                         Ext.Ajax.request({
+                            url: this.target.geoStoreBaseURL+'categories/',
+                            method: 'POST',
+                            headers:{
+                                'Content-Type' : 'text/xml',
+                                'Accept' : 'application/json, text/plain, text/xml',
+                                'Authorization' : this.getAuth()
+                            },
+                            params:xml,
+                            scope: this,
+                            success: function(response, opts){
+                                this.geostoreSource=true;
+                                this.actions[0].enable();
+                            },
+                            failure:  function(response, opts){
+                                Ext.Msg.show({
+                                title: this.gsErrorTitle,
+                                msg: this.gsCreateCategoryError+this.getErrorMsg(response),
+                                buttons: Ext.Msg.OK,
+                                icon: Ext.MessageBox.ERROR
+                                });
+                             }
+                        }); 
+                    },
+                       icon: Ext.MessageBox.QUESTION,
+                       scope: this
+                    });
+
+
+           
+            }
+    },
+    /** private: method[checkLayerSourceCategory]
+     *  ``Function``Check if GeoStore LAYERS_SOURCE CATEGORY exist
+     *
+     */
+    checkLayerSourceCategory:function(){
+    //Check if GeoStore CATEGORY LAYERS_SOURCE exist
+        Ext.Ajax.request({
+           url: this.target.geoStoreBaseURL+'categories/count/LAYERS_SOURCE',
+           method: 'GET',
+           headers:{
+              'Content-Type' : 'text/xml',
+              'Accept' : 'application/json, text/plain, text/xml',
+              'Authorization' : this.getAuth()
+           },
+           scope: this,
+            success: function(response, opts){
+            if(response.responseText==0){
+                this.createLayerSourceCategory();
+            }
+            else{ 
+                this.geostoreSource=true
+                this.getUserLayersSources();            }
+           },
+           failure:  function(response, opts){
+              Ext.Msg.show({
+                 title: this.gsErrorTitle,
+                 msg: this.gsCategoryCheckError+this.getErrorMsg(response),
+                 buttons: Ext.Msg.OK,
+                 icon: Ext.MessageBox.ERROR
+              });
+          }
+        }); 
+    },
+    /** private: method[getOwner]
+     *  ``Function``Get owner attribute form geostore resource attributes
+     *
+     */
+    getOwner:function(attr){
+        var owner=null;
+        var attributes=[];
+
+        if(attr.attribute instanceof Array)
+            attributes=attr.attribute;
+        else 
+            attributes.push(attr.attribute);
+        
+        for(var i = 0; i<attributes.length;i++)
+               if(attributes[i].name=='owner'){
+                owner=attributes[i].value;
+                break;
+               }
+        return owner;
+    },
+    /** private: method[generateUUID]
+     *  ``Function``Create UUID
+     *
+     */
+    generateUUID:function () {
+    var d = new Date().getTime();
+    var uuid = 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, function(c) {
+        var r = (d + Math.random()*16)%16 | 0;
+        d = Math.floor(d/16);
+        return (c=='x' ? r : (r&0x3|0x8)).toString(16);
+    });
+    return uuid;
+    },
+    /** private: method[getErrorMsg]
+     *  ``Function``Format geostore response errror
+     *
+     */
+    getErrorMsg:function(response){
+        return defaultErrMsg = " "+response.statusText + "(status " + response.status + "):  " + response.responseText;
+    },
+    /** private: method[toolBarManager]
+     *  ``Function``Include the logic used to enable, disable toolbare button
+     *              based on user permissions and source
+     *
+     */
+    toolBarManager:function(source){
+        var capGridToolbar = this.capGrid.getTopToolbar();
+        if(source.ptype == "gxp_wmssource" && source.gs_group=='Personal'){
+                        capGridToolbar.items.item(4).enable();
+                        capGridToolbar.items.item(5).enable();
+                        }else{
+                        capGridToolbar.items.item(4).disable();
+                        capGridToolbar.items.item(5).disable();
+                    }
+        if(this.advancedUser || this.roleAdmin){
+            capGridToolbar.items.item(3).enable();
+        }else
+        capGridToolbar.items.item(3).disable();
+
+
+    },
+    /** private: method[hasGroup]
+     *  ``Function`` Check if users has passed group
+     *
+     */
+    hasGroup: function(user, targetGroups){
+                if(user && user.groups && targetGroups){
+                    var groupfound = false;
+                    for (var key in user.groups.group) {
+                        if (user.groups.group.hasOwnProperty(key)) {
+                            var g = user.groups.group[key];
+                            if(g.groupName && targetGroups.indexOf(g.groupName) > -1 ){
+                                groupfound = true;
+                            }
+                        }
+                    }
+                    return groupfound;
+                }
+                
+                return false;
+            },
+    /** private: method[getPersonalInsertIdx]
+     *  ``Function`` Find combosource store index for personal resource
+     */     
+     getPersonalInsertIdx:function(){
+        var st =this.getSourceComboBox().getStore();
+        var idx= st.find('gs_group','Personal');
+        return (idx==-1)?st.getTotalCount():idx+1;    
+    }
+
+
+});
+
+Ext.preg(gxp.plugins.he.AddLayersGeoStore.prototype.ptype, gxp.plugins.he.AddLayersGeoStore);

--- a/mapcomposer/app/applications/he/static/script/widgets/GeoStoreNewSourceWindow.js
+++ b/mapcomposer/app/applications/he/static/script/widgets/GeoStoreNewSourceWindow.js
@@ -1,0 +1,651 @@
+/**
+ *  Copyright (C) 2007 - 2015 GeoSolutions S.A.S.
+ *  http://www.geo-solutions.it
+ *
+ *  GPLv3 + Classpath exception
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+/**
+ * @author Andrea Cappugi (kappu72@gmail.com)
+ */
+
+
+/** api: (define)
+ *  module = gxp.he
+ *  class = NewSourceWindowGeoStore
+ *  extends = gxp.NewSourceWindow
+ */
+Ext.namespace('gxp.he');
+
+/** api: constructor
+ * .. class:: gxp.he.NewSourceWindowGeoStore(config)
+ *
+ */
+gxp.he.NewSourceWindowGeoStore = Ext.extend(gxp.NewSourceWindow, {
+
+    /** api: config[groupsLabel]
+     *  ``String``
+     *  Group multiselect label (i18n).
+     */
+    groupsLabel:'Groups',
+
+    /** api: config[gsErrorTitle]
+     *  ``String``
+     *  Error message title!
+     */
+    gsErrorTitle:"Geostore Error",
+
+    /** api: config[gsGetPermissionError]
+     *  ``String``
+     *  Error message title!
+     */
+    gsGetPermissionError:"Unable to retrieve resource permissions.",
+
+     /** api: event[server-added]
+     * Fired with the URL that the user provided as a parameter when the form 
+     * is submitted.
+     */
+    initComponent: function() {
+        this.addEvents("server-added");
+        this.urlTextField = new Ext.form.TextField({
+            fieldLabel: "URL (*)",
+            allowBlank: false,
+            width: 220,
+            labelStyle: "width: 50px;",
+            msgTarget: "under",
+            validator: this.urlValidator.createDelegate(this)
+        });
+        this.roleAdmin=(this.target && this.target.userDetails && this.target.userDetails.user.role == "ADMIN");
+        var store = [];
+        for(var count = 0, l = this.availableSources.length; count < l; count++) {
+            var source = this.availableSources[count];
+            store.push([source.name, source.description]);
+        }
+        this.form = new Ext.Panel({
+            layout: "form",
+            items: [{
+                xtype: 'combo',
+                width: 220,
+                labelStyle: "width: 50px;",
+                ref: "../sourceType",
+                name: 'type',
+                fieldLabel: this.sourceTypeLabel,
+                ref: "sourceType",
+                value: 'WMS',
+                mode: 'local',
+                triggerAction: 'all',
+                store: store,
+                listeners: {
+                    scope: this,
+                    select: function(combo, record, index) {
+                        var sourceType = store[index][0];
+                        if(sourceType == "WMS"){
+                            this.advancedOptions.show();
+                        }else{
+                            this.advancedOptions.hide();
+                        }
+                    }
+                }
+            }, this.urlTextField,
+            {
+                                    xtype:'gxp_usergroupmultiselect',
+                                    ref:"groupPermissions",
+                                    disabled:!this.isNewSource,
+                                    hidden:!this.roleAdmin,
+                                    labelStyle: "width: 50px;",
+                                    fieldLabel:this.groupsLabel,
+                                    url: this.target.geoStoreBaseURL +'/usergroups',
+                                    auth: this.auth,
+                                    name:'groupId',
+                                    editable:false,
+                                    width:'auto',
+                                    allowBlank:true,
+                                    target: this.target
+                                },
+            {
+                xtype: "fieldset",
+                title: this.advancedOptionsTitle,
+                ref: "../advancedOptions",
+                collapsible: true,
+                collapsed: true,
+                hidden: false,
+                items:[{
+                    xtype: "tabpanel",
+                    bodyStyle: "padding: 5px",
+                    deferredRender: false,
+                    activeTab: 0,
+                    items: [
+                        {
+                            xtype: "form",
+                            title: this.generalTabTitle,
+                            ref: "../../../generalForm",    
+                            labelWidth: 80,
+                            height: 120,
+                            items: [{
+                                    xtype: "textfield",
+                                    name: "title",
+                                    width: 147,
+                                    allowBlank: true,
+                                    fieldLabel: this.titleLabel
+                                },{
+                                    xtype: 'combo',
+                                    name: "version",
+                                    width: 147,
+                                    allowBlank: false,
+                                    fieldLabel: this.versionLabel,
+                                    value: "1.1.1",
+                                    mode: 'local',
+                                    triggerAction: 'all',
+                                    mode: "local",
+                                    forceSelection: true,
+                                    editable: false,
+                                    valueField: "version",
+                                    displayField: "version",
+                                    store: new Ext.data.ArrayStore({
+                                        fields: ["version"],
+                                        data:  [["1.1.1"], ["1.3.0"]]
+                                    })
+                                },{
+                                    xtype: "textfield",
+                                    name: "authParam",
+                                    width: 147,
+                                    allowBlank: true,
+                                    fieldLabel: this.authParamLabel
+                            }]
+                        }, {            
+                            xtype: "form",
+                            title: this.cacheTabTitle,
+                            ref: "../../../cacheForm",  
+                            labelWidth: 80,
+                            height: 120,
+                            items: [{
+                                xtype: "numberfield",
+                                allowBlank: true,
+                                name: "minx",
+                                fieldLabel: this.minXLabel
+                            },{
+                                xtype: "numberfield",
+                                allowBlank: true,
+                                name: "miny",
+                                fieldLabel: this.minYLabel
+                            },{
+                                xtype: "numberfield",
+                                allowBlank: true,
+                                name: "maxx",
+                                fieldLabel: this.maxXLabel
+                            },{
+                                xtype: "numberfield",
+                                allowBlank: true,
+                                name: "maxy",
+                                fieldLabel: this.maxYLabel
+                            }]
+                        }, {
+                            layout: "form",
+                            title: this.paramsTabTitle,
+                            height: 120,
+                            items: [
+                                new Ext.grid.PropertyGrid({
+                                    header: false,
+                                    height: 90,
+                                    autoScroll: false,
+                                    hideHeaders: true,
+                                    selModel: new Ext.grid.RowSelectionModel(),
+                                    ref: "../../../../paramGrid",                                   
+                                    listeners: {
+                                        scope: this,
+                                        rowclick: function(el, rowIndex, evt){
+                                            this.paramGrid.removeButton.enable();
+                                        },
+                                        afterrender: function(propertyGrid) {
+                                            // register listeners on relevant grid editors
+                                            // (workaround for issue #547: https://github.com/geosolutions-it/MapStore/issues/547)
+                                            if (Ext.isChrome) {
+                                                var cm = propertyGrid.getColumnModel();
+                                                var fieldTypes = ['date', 'string', 'number']; // fix only editors using a TextField or a subclass of TextField
+                                                Ext.each(fieldTypes, function(fieldType) {
+                                                    var editor = cm.editors[fieldType];
+                                                    if (editor) {
+                                                        editor.addListener("beforestartedit", function() {
+                                                            var currentScroll = propertyGrid.getGridEl().child(".x-grid3").getScroll();
+                                                            // save currentScroll as a property of the grid
+                                                            propertyGrid.savedScroll = currentScroll;
+                                                            //console.log("saved grid scroll value: { left: " + currentScroll.left + ", top: " + currentScroll.top + "}");
+                                                        });
+                                                        
+                                                        editor.addListener("startedit", function() {
+                                                            var savedScroll = propertyGrid.savedScroll;
+                                                            if (savedScroll) {
+                                                                var el = propertyGrid.getGridEl().child(".x-grid3");
+                                                                var delayedTask = new Ext.util.DelayedTask(function() {
+                                                                    // restore grid's scroll value
+                                                                    el.scrollTo("left", savedScroll.left);
+                                                                    el.scrollTo("top", savedScroll.top);
+                                                                    //console.log("restored grid scroll value: { left: " + savedScroll.left + ", top: " + savedScroll.top + "}");
+                                                                });
+                                                                delayedTask.delay(10);
+                                                            }                                                   
+                                                        });
+                                                    }
+                                                });
+                                            }
+                                        }
+                                    },                                  
+                                    bbar:["->",{
+                                        text: this.addParamButtonText,
+                                        iconCls: "add",
+                                        scope: this,
+                                        handler: function(){            
+                                            var paramForm = new Ext.form.FormPanel({
+                                                width: 300,
+                                                items: [
+                                                    {
+                                                        xtype: "combo",
+                                                        ref: "propertyName",
+                                                        fieldLabel: this.propNameLabel,
+                                                        width: 100,
+                                                        store: new Ext.data.ArrayStore({
+                                                            fields: ["params"],
+                                                            data :  this.availableVendorOptions
+                                                        }),
+                                                        listeners:{
+                                                            scope: this,
+                                                            select: function(combo, record, index){
+                                                                var param = record.get("params");
+                                                                if(param == "FORMAT"){
+                                                                    paramForm.propertyValue.hide();
+                                                                    paramForm.tiledCombo.hide();
+                                                                    paramForm.formatCombo.show();
+                                                                }else if(param == "TILED"){
+                                                                    paramForm.propertyValue.hide();
+                                                                    paramForm.formatCombo.hide();
+                                                                    paramForm.tiledCombo.show();                                                                
+                                                                }else{
+                                                                    paramForm.formatCombo.hide();
+                                                                    paramForm.tiledCombo.hide();
+                                                                    paramForm.propertyValue.show();
+                                                                }
+                                                            }
+                                                        },
+                                                        mode: "local",
+                                                        forceSelection: true,
+                                                        triggerAction: "all",
+                                                        editable: false,
+                                                        valueField: "params",
+                                                        displayField: "params"
+                                                    },
+                                                    {
+                                                        xtype: "combo",
+                                                        ref: "formatCombo",
+                                                        fieldLabel: this.propValueLabel,
+                                                        width: 100,
+                                                        hidden: true,
+                                                        store: new Ext.data.ArrayStore({
+                                                            fields: ["format"],
+                                                            data :  this.availableFormats
+                                                        }),
+                                                        mode: "local",
+                                                        forceSelection: true,
+                                                        triggerAction: "all",
+                                                        editable: false,
+                                                        valueField: "format",
+                                                        displayField: "format"
+                                                    },
+                                                    {
+                                                        xtype: "combo",
+                                                        ref: "tiledCombo",
+                                                        fieldLabel: this.propValueLabel,
+                                                        width: 100,
+                                                        hidden: true,
+                                                        store: new Ext.data.ArrayStore({
+                                                            fields: ["tiled"],
+                                                            data :  [["true"], ["false"]]
+                                                        }),
+                                                        mode: "local",
+                                                        forceSelection: true,
+                                                        triggerAction: "all",
+                                                        editable: false,
+                                                        valueField: "tiled",
+                                                        displayField: "tiled"
+                                                    },
+                                                    {
+                                                        hidden: false,
+                                                        width: 100,
+                                                        xtype: 'textfield',
+                                                        ref: "propertyValue",
+                                                        allowBlank: false,
+                                                        fieldLabel: this.propValueLabel,
+                                                        flex: 1
+                                                    }
+                                                ]
+                                            });
+                                            
+                                            var paramWindow = new Ext.Window({
+                                                title: this.paramsWinTitle,
+                                                width: 315,
+                                                modal: true,
+                                                items: [
+                                                    paramForm
+                                                ],
+                                                bbar: ["->", {
+                                                    text: this.okButtonText,
+                                                    iconCls: "save",
+                                                    scope: this,
+                                                    handler: function(){
+                                                        var propertyName = paramForm.propertyName;
+                                                        var propertyValue = paramForm.propertyValue;
+                                                        var tiledCombo = paramForm.tiledCombo;
+                                                        var formatCombo = paramForm.formatCombo;
+                                                        
+                                                        if(propertyName.isDirty() && propertyName.isValid()){
+                                                            if(propertyValue.isDirty() && propertyValue.isValid()){                                                         
+                                                                this.paramGrid.setProperty(propertyName.getValue(), propertyValue.getValue(), true);                                                        
+                                                                paramWindow.close();
+                                                            }else if(tiledCombo.isDirty() && tiledCombo.isValid()){
+                                                                this.paramGrid.setProperty(propertyName.getValue(), tiledCombo.getValue(), true);                                                       
+                                                                paramWindow.close();
+                                                            }else if(formatCombo.isDirty() && formatCombo.isValid()){
+                                                                this.paramGrid.setProperty(propertyName.getValue(), formatCombo.getValue(), true);                                                      
+                                                                paramWindow.close();
+                                                            }else{
+                                                                Ext.Msg.show({
+                                                                     title: this.addPropDialogTitle,
+                                                                     msg: this.addPropDialogMsg,
+                                                                     width: 300,
+                                                                     icon: Ext.MessageBox.WARNING
+                                                                });
+                                                            }
+                                                        }
+                                                    }
+                                                }, {    
+                                                    text: this.cancelButtonText,
+                                                    scope: this,
+                                                    iconCls: "cancel",
+                                                    handler: function(){
+                                                        paramWindow.close();
+                                                    }
+                                                }]
+                                            });
+                                            
+                                            paramWindow.show();
+                                        }
+                                    },{
+                                        text: this.removeButtonText,
+                                        scope: this,
+                                        disabled: true,
+                                        iconCls: "delete",
+                                        ref: "../removeButton",
+                                        handler: function(){
+                                            var gridSelModel = this.paramGrid.getSelectionModel();
+                                            var selected = gridSelModel.getSelected();
+                                            
+                                            if(selected){
+                                                this.paramGrid.removeProperty(selected.id);
+                                            }else{
+                                                Ext.Msg.show({
+                                                     title: this.removePropDialogTitle,
+                                                     msg: this.removePropDialogMsg + selected.id,
+                                                     width: 300,
+                                                     icon: Ext.MessageBox.WARNING
+                                                });
+                                            }                                           
+                                        }
+                                    }],
+                                    customEditors: {
+                                        "FORMAT": new Ext.grid.GridEditor(new Ext.form.ComboBox({
+                                                store: new Ext.data.ArrayStore({
+                                                    fields: ["format"],
+                                                    data :  this.availableFormats
+                                                }),
+                                                mode: "local",
+                                                forceSelection: true,
+                                                triggerAction: "all",
+                                                editable: false,
+                                                valueField: "format",
+                                                displayField: "format"
+                                        }))
+                                    },
+                                    source:{}
+                                })
+                            ]
+                        }
+                    ]
+                }, {
+                    xtype: "label",
+                    text: this.mandatoryLabelText,
+                    style: "color: red;"
+                }]
+            }],
+            border: false,
+            labelWidth: 30,
+            bodyStyle: "padding: 5px",
+            autoScroll: true,
+            listeners: {
+                afterrender: function() {
+                    
+                    this.urlTextField.focus(false, true);
+                },
+                scope: this
+            }
+        });
+
+        this.bbar = [
+            new Ext.Button({
+                text: this.cancelText,
+                iconCls: "gxp-icon-removefilter",
+                handler: function() {
+                    this.hide();
+                },
+                scope: this
+            }),
+            new Ext.Toolbar.Fill(),
+            new Ext.Button({
+                text: this.isNewSource === true ? this.addServerText : this.editServerText,
+                iconCls: "add",
+                ref: "../sourceButton",
+                handler: function() {
+                    // Clear validation before trying again.
+                    this.error = null;
+                    
+                    if (this.urlTextField.validate()) {
+                        var sourceUrl = this.urlTextField.getValue();
+                        
+                        var sourceCfg = {
+                            url: sourceUrl
+                        };
+                                                
+                        var generalForm = this.generalForm.getForm();
+                        if(generalForm.isValid()){
+                            var generalCfgForm = generalForm.getValues();
+                            if(generalCfgForm){
+                                for(property in generalCfgForm){
+                                    if(generalCfgForm[property] == ""){
+                                        delete generalCfgForm[property];
+                                    }
+                                }
+                                
+                                Ext.applyIf(sourceCfg, generalCfgForm);
+                            }
+                        };
+                        var cacheForm = this.cacheForm.getForm();
+                        if(cacheForm.isValid()){
+                            var cacheCfgForm = cacheForm.getValues();
+                            if(cacheCfgForm){
+                                var filled = true;
+                                for(property in cacheCfgForm){
+                                    if(cacheCfgForm[property] == ""){
+                                        filled = false;
+                                    }
+                                }
+                                
+                                if(filled){
+                                    Ext.applyIf(sourceCfg, {
+                                        layersCachedExtent: [cacheCfgForm.minx, cacheCfgForm.miny, cacheCfgForm.maxx, cacheCfgForm.maxy]
+                                    });
+                                }
+                            }
+                        }
+                        
+                        var paramGridStore = this.paramGrid.getStore();
+                        var paramGridRecords = paramGridStore.getRange(0, paramGridStore.getCount());   
+
+                        if(paramGridRecords){
+                            var layerBaseParams = {};
+                            for(var i=0; i<paramGridRecords.length; i++){
+                                var record = paramGridRecords[i];
+                                if(record){
+                                    layerBaseParams[record.data.name] = record.data.value;
+                                }
+                            }
+                            
+                            Ext.applyIf(sourceCfg, {
+                                layerBaseParams: layerBaseParams
+                            });
+                        }
+                    
+                        if(!this.sourceId){
+                            this.fireEvent("server-added", sourceUrl, this.form.sourceType.getValue(), sourceCfg,this.form.groupPermissions.getValue());
+                        }else{
+                            this.fireEvent("server-modified", sourceUrl, this.form.sourceType.getValue(), sourceCfg, this.sourceId,this.form.groupPermissions.getValue());
+                            this.sourceId = undefined;
+                            
+                            // Re-enabled fields
+                            this.urlTextField.enable();                     
+                            this.form.sourceType.enable();  
+                        }                           
+                    }else{
+                        Ext.Msg.show({
+                             title: this.newSourceDialogTitle,
+                             msg: this.newSourceDialogMsg,
+                             width: 300,
+                             icon: Ext.MessageBox.WARNING
+                        });
+                    }
+                },
+                scope: this
+            })
+        ];
+    
+        this.items = this.form;
+
+        gxp.NewSourceWindow.superclass.initComponent.call(this);
+
+        this.form.on("render", function() {
+            this.loadMask = new Ext.LoadMask(this.form.getEl(), {msg:this.contactingServerText});
+        }, this);
+
+        this.on("hide", function() {
+            // Reset values so it looks right the next time it pops up.
+            this.error = null;
+            this.showPermissions=false;
+            this.urlTextField.validate(); // Remove error text.
+            this.urlTextField.setValue("");
+            this.loadMask.hide();
+        }, this);
+
+        this.on("server-added", function(url) {
+            this.setLoading();
+            var success = function(record) {
+                this.hide();
+            };
+
+            var failure = function() {
+                this.setError(this.sourceLoadFailureMessage);
+            };
+
+            // this.explorer.addSource(url, null, success, failure, this);
+            this.addSource(url, success, failure, this);
+        }, this);
+
+
+           this.on("beforeshow",function (){
+                    if((this.isNewSource && this.roleAdmin) || this.showPermissions){
+                        this.form.groupPermissions.show();
+                    }else 
+                        this.form.groupPermissions.hide();
+                },this);
+
+    },
+    
+    /** public: method[showWindow]
+     */
+    showWindow: function(){
+        this.sourceId=undefined;
+        gxp.he.NewSourceWindowGeoStore.superclass.showWindow.call(this);
+    },
+
+    /** public: method[bindSource]
+     */
+    bindSource: function(source){
+        if(source){
+            if(source.gsId && this.roleAdmin){
+                 this.showPermissions=true;
+                if(this.form.rendered){
+                    this.form.groupPermissions.disable();
+                }
+                else{
+                    this.form.groupPermissions.disabled=true;
+                }
+                this.getResourcePermissions(source.gsId);
+            }else this.showPermissions=false;               
+        }
+        gxp.he.NewSourceWindowGeoStore.superclass.bindSource.call(this,source);
+    },
+
+    /** private: method[getResourcePermissions] 
+     * :param: resource ID
+     *
+     * Get resource permissions from geostore
+     */
+    getResourcePermissions:function(rId){
+         Ext.Ajax.request({
+           url: this.target.geoStoreBaseURL+'resources/resource/'+rId+'/permissions',
+           method: 'GET',
+           headers:{
+              'Content-Type' : 'text/xml',
+              'Accept' : 'application/json, text/plain, text/xml',
+              'Authorization' : this.auth
+           },        
+           scope: this,
+           success: function(response, opts){              
+                this.form.groupPermissions.enable();
+                var per=this.form.groupPermissions;
+                var rulesList =Ext.util.JSON.decode(response.responseText).SecurityRuleList;
+                var rules=[];
+                if(rulesList && rulesList.SecurityRule instanceof Array)
+                   rules=rulesList.SecurityRule;
+                else if(rulesList.SecurityRule) 
+                   rules.push(rulesList.SecurityRule);
+                var groups=[];               
+                for(var i=0;i<rules.length;i++){
+                    var rule=rules[i];
+                    if(rule.group)
+                        groups.push(rule.group.id);
+                }
+                per.setValue(groups);            
+           },
+           failure:  function(response, opts){
+              Ext.Msg.show({
+                 title: this.gsErrorTitle,
+                 msg: this.gsGetPermissionError+" "+response.statusText + "(status " + response.status + "):  " + response.responseText,
+                 buttons: Ext.Msg.OK,
+                 icon: Ext.MessageBox.ERROR
+              });
+          }
+        }); 
+
+    }       
+
+
+});

--- a/mapcomposer/app/applications/he/static/script/widgets/form/UserGroupMultiSelect.js
+++ b/mapcomposer/app/applications/he/static/script/widgets/form/UserGroupMultiSelect.js
@@ -1,0 +1,178 @@
+/*
+ *  Copyright (C) 2007 - 2014 GeoSolutions S.A.S.
+ *  http://www.geo-solutions.it
+ *
+ *  GPLv3 + Classpath exception
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/** api: (define)
+ *  module = gxp.form
+ *  class = UserGroupMultiSelect
+ *  
+ */
+Ext.ns('gxp.form');
+
+/**
+ * Class: UserGroupComboBox
+ * User group simple combobox
+ * 
+ * Inherits from:
+ *  - <Ext.ux.form.MultiSelect>
+ *
+ */
+gxp.form.UserGroupMultiSelect = Ext.extend(Ext.ux.form.MultiSelect, {
+
+    /** xtype = gxp_usergroupmultiselect **/
+    xtype: "gxp_usergroupmultiselect",
+
+    // i18n
+    fieldLabel: "User group",
+
+    // base config
+    typeAhead: true,
+    triggerAction: 'all',
+    lazyRender:true,
+    valueField: 'id',
+    displayField: 'name',
+
+    // specifig config
+    url: null,
+    auth: null,
+    width:175,
+    // select  by default by name
+    defaultSelection: null,
+
+    // by default the combo include all groups in the system (include everyone group)
+    showAll: true,
+
+    initComponent: function(){
+
+        // headers
+        var defaultHeaders = {'Accept': 'application/json'};
+        if(this.auth){
+            defaultHeaders['Authorization'] = this.auth;
+        }
+
+        // add all
+        var url = this.url;
+        if(url && this.showAll){
+            if(url.indexOf("?")<0){
+                url += "?all=true";
+            }else{
+                url += "&all=true";
+            }
+        }
+
+        // If user is admin, load the groups from geostore url, otherwise load from user context
+        var role,groups;
+        if(sessionStorage && sessionStorage["userDetails"]){
+            var userDetails = sessionStorage["userDetails"];
+            userDetails = Ext.decode(userDetails);
+            role = userDetails.user.role;
+            groups = userDetails.user.groups.group;
+        }else{
+            role = this.target && this.target.user && this.target.user.role == "ADMIN";
+        }
+        var userIsAdmin = (role =="ADMIN");
+        // store 
+        this.store = {
+            xtype: "jsonstore",
+            fields: [
+                {name:'id', mapping:'id'},
+                {name:'name', mapping:'groupName'}
+            ],
+            listeners:{
+                load: function(store){
+                    this.fireEvent("storeload", store, this);
+                    this.loadDefault(store);
+                },
+                scope: this
+            }
+        };
+
+        if(userIsAdmin){
+            // load from geostore
+            Ext.apply(this.store,{
+                xtype: "jsonstore",
+                idProperty: 'id',
+                root: 'UserGroupList.UserGroup',
+                autoLoad: true,
+                proxy: new Ext.data.HttpProxy({
+                    url: url,
+                    restful: true,
+                    method : 'GET',
+                    disableCaching: true,
+                    failure: function (response) {
+                        Ext.Msg.show({
+                           title: "Error",
+                           msg: response.statusText + "(status " + response.status + "):  " + response.responseText,
+                           buttons: Ext.Msg.OK,
+                           icon: Ext.MessageBox.ERROR
+                        });
+                    },
+                    headers: defaultHeaders
+                })
+            });
+        }else{
+            // load user groups from user logged details
+            this.autoLoad = true;
+            this.mode = 'local';
+            var data = [];
+            //if not alredy loaded from the session storage
+            if (!groups  && this.target){
+                    if(this.target.user.groups.group && this.target.user.groups.group.length){
+                    // it have more than one group
+                    data = this.target.user.groups.group;
+                }else if(this.target.user.groups.group){
+                    // only one group
+                    data.push(this.target.user.groups.group);
+                }
+            }else if(groups){
+                if(groups instanceof Array){
+                    data = groups;
+                }else{
+                    data = [groups] ;
+                }
+                
+            }
+            
+            Ext.apply(this.store,{
+                mode: "local",
+                data: data
+            });
+        }
+        
+        gxp.form.UserGroupMultiSelect.superclass.initComponent.call(this, arguments);
+    },
+
+    /**
+     * private:[loadDefault]
+     * 
+     * Select `this.defaultSelection` if it's configurated
+     **/
+    loadDefault: function(store){
+        if(this.defaultSelection){
+            store.each(function(record){
+                if(this.defaultSelection == record.get("name") || this.defaultSelection == record.get("groupName")){
+                    this.setValue(record.get("id"));
+                }
+            }, this);   
+        }
+    }
+});
+
+/** api: xtype = msm_usergroupcombobox */
+Ext.reg(gxp.form.UserGroupMultiSelect.prototype.xtype, gxp.form.UserGroupMultiSelect);

--- a/mapcomposer/app/applications/he/templates/composer.html
+++ b/mapcomposer/app/applications/he/templates/composer.html
@@ -72,6 +72,13 @@
     <script type="text/javascript" src="translations/it.js"></script>
     <script type="text/javascript" src="translations/de.js"></script>
     <script type="text/javascript" src="translations/es.js"></script>
+
+    <!-- he translation data  -->
+    <script type="text/javascript" src="hetranslations/en.js"></script>
+    <script type="text/javascript" src="hetranslations/fr.js"></script>
+    <script type="text/javascript" src="hetranslations/it.js"></script>
+    <script type="text/javascript" src="hetranslations/de.js"></script>
+    <script type="text/javascript" src="hetranslations/es.js"></script>
 	
 	<!-- uncomment to have  welcome screen
 	<script type="text/javascript">

--- a/mapcomposer/app/applications/he/templates/gcd.html
+++ b/mapcomposer/app/applications/he/templates/gcd.html
@@ -84,6 +84,13 @@
         <script type="text/javascript" src="translations/de.js"></script>
         <script type="text/javascript" src="translations/es.js"></script>
 
+        <!-- he translation data  -->
+        <script type="text/javascript" src="hetranslations/en.js"></script>
+        <script type="text/javascript" src="hetranslations/fr.js"></script>
+        <script type="text/javascript" src="hetranslations/it.js"></script>
+        <script type="text/javascript" src="hetranslations/de.js"></script>
+        <script type="text/javascript" src="hetranslations/es.js"></script>
+
         <!-- uncomment to have  welcome screen -->
         <script type="text/javascript">
             hideLoad = function(){

--- a/mapcomposer/app/applications/he/templates/login.html
+++ b/mapcomposer/app/applications/he/templates/login.html
@@ -32,7 +32,8 @@
 	
     <!-- canvg-1.2 resources -->
 	<script type="text/javascript" src="script/canvg-1.2.js"></script> 
-	
+	 <script type="text/javascript" src="script/ux.js"></script>
+   
     <!-- gxp resources -->
     <link rel="stylesheet" type="text/css" href="externals/gxp/src/theme/all.css">
     <script type="text/javascript" src="script/gxp.js"></script> 
@@ -55,7 +56,6 @@
     <!--[if IE]><link rel="stylesheet" type="text/css" href="theme/app/ie.css"/><![endif]-->        
 
     <script type="text/javascript" src="script/GeoExplorer.js"></script>
-    <script type="text/javascript" src="script/ux.js"></script>
    
     <!-- csw resources -->
     <link rel="stylesheet" type="text/css" href="externals/csw/css/csw.css">
@@ -75,6 +75,13 @@
     <script type="text/javascript" src="translations/it.js"></script>
     <script type="text/javascript" src="translations/de.js"></script>
     <script type="text/javascript" src="translations/es.js"></script>
+
+    <!-- he translation data  -->
+    <script type="text/javascript" src="hetranslations/en.js"></script>
+    <script type="text/javascript" src="hetranslations/fr.js"></script>
+    <script type="text/javascript" src="hetranslations/it.js"></script>
+    <script type="text/javascript" src="hetranslations/de.js"></script>
+    <script type="text/javascript" src="hetranslations/es.js"></script>
 	
 	<!-- uncomment to have  welcome screen
 	<script type="text/javascript">


### PR DESCRIPTION
Added geostore support to create update and delete layers source resources in addLayers plugin. It also allow to set group permission for the created  resources (Only for admin role users).
Users in Advanced_Users user group can create and save in geostore layers_source resources.
Other user can only see default sources and geostore sources that admin has created for their group.
Resources are divided in Public and Default sources. User can edit and save only their own resources.