### PR TITLE
Added configurability for spatialSelectorFieldset and attributeFieldSet

### DIFF
--- a/mapcomposer/app/applications/he/static/config/login.js
+++ b/mapcomposer/app/applications/he/static/config/login.js
@@ -359,6 +359,9 @@
           "id": "bboxquery",
           "filterLayer":true,
           "outputConfig":{
+          		  "spatialSelectorFieldset":{
+          		  	"collapsed":true
+          		  },
                   "outputSRS": "EPSG:900913",
                   "selectStyle":{
                           "strokeColor": "#ee9900",

--- a/mapcomposer/app/static/externals/gxp/src/script/plugins/SpatialSelectorQueryForm.js
+++ b/mapcomposer/app/static/externals/gxp/src/script/plugins/SpatialSelectorQueryForm.js
@@ -414,7 +414,7 @@ gxp.plugins.SpatialSelectorQueryForm = Ext.extend(gxp.plugins.QueryForm, {
             autoScroll: true,
             id: this.getFormId(),
             items: [
-            {
+            Ext.apply({
                 xtype: "fieldset",
                 ref: "spatialSelectorFieldset",
                 title: spatialSelectorOutput.title,
@@ -430,8 +430,8 @@ gxp.plugins.SpatialSelectorQueryForm = Ext.extend(gxp.plugins.QueryForm, {
                         this.spatialSelector.reset();
                     }
                 }
-            },
-            {
+            },this.outputConfig.spatialSelectorFieldset||{}),
+            Ext.apply({
                 xtype: "fieldset",
                 ref: "attributeFieldset",
                 title: this.queryByAttributesText,
@@ -448,7 +448,7 @@ gxp.plugins.SpatialSelectorQueryForm = Ext.extend(gxp.plugins.QueryForm, {
                         }
                     }
 				}
-            }],
+            },this.outputConfig.attributeFieldset||{})],
             bbar: bbarButtons
         }, config || {});
 		


### PR DESCRIPTION
It's possible to configure SpatialSelectorQueryForm's spatialSelectorFieldset and attributeFieldSet passing config object in outputConfig.
To uncheck by defautl spatialSelectorFieldset add in SpatialSelectorQueryForm's outputConfig object collapsed:true property.
I.e.
 "outputConfig":{
          		  "spatialSelectorFieldset":{
          		  	"collapsed":true
          		  }
}