### PR TITLE
Get Bing API key from the configuration

### DIFF
--- a/mapcomposer/app/static/config/common/localConfig.js
+++ b/mapcomposer/app/static/config/common/localConfig.js
@@ -5,5 +5,8 @@
 var localConfig = {
    geoStoreBase: "",
    proxy:"/http_proxy/proxy/?url=",
-   defaultLanguage: "en"
+   defaultLanguage: "en",
+   apikeys:{
+       "Bing" : "insert-your-Bing-API-key"
+   }
 };

--- a/mapcomposer/app/static/externals/gxp/src/script/plugins/BingSource.js
+++ b/mapcomposer/app/static/externals/gxp/src/script/plugins/BingSource.js
@@ -87,13 +87,19 @@ gxp.plugins.BingSource = Ext.extend(gxp.plugins.LayerSource, {
      *  ``String``
      *  API key generated from http://bingmapsportal.com/ for your domain.
      */
-    apiKey: "AqTGBsziZHIJYYxgivLBf0hVdrAk9mWO5cQcb8Yux8sW5M8c8opEC2lZqKR1ZZXf",
+    apiKey: null,
     
     /** api: method[createStore]
      *
      *  Creates a store of layer records.  Fires "ready" when store is loaded.
      */
     createStore: function() {
+        
+        // If the apiKey has not been configured in the Source, get the default from the config
+        if(this.apiKey == null && this.target
+        && this.target.apikeys && this.target.apikeys.Bing ){
+            this.apiKey = this.target.apikeys.Bing;
+        };
         
         var layers = [
             new OpenLayers.Layer.Bing({

--- a/mapcomposer/app/templates/composer.html
+++ b/mapcomposer/app/templates/composer.html
@@ -445,7 +445,8 @@
 				scaleOverlayUnits: serverConfig.scaleOverlayUnits,
                 georeferences: georeferences_data,
                 map: serverConfig.map,
-				customTools: serverConfig.customTools
+                customTools: serverConfig.customTools,
+                apikeys: serverConfig.apikeys
             }, mapIdentifier, authorization && authorization == "false" ? null: authorization, fullScreen, templateId);   
 			
             app.on({

--- a/mapcomposer/app/templates/viewer.html
+++ b/mapcomposer/app/templates/viewer.html
@@ -293,7 +293,8 @@
                     },
                     georeferences: georeferences_data,
                     map: serverConfig.map,
-					customTools: serverConfig.customTools
+                    customTools: serverConfig.customTools,
+                    apikeys: serverConfig.apikeys
                 }, mapIdentifier, false, fullScreen);   
 			
                 app.on({


### PR DESCRIPTION
The default, not working, API key has been removed.
The API key can be set in the "apikeys" object, allowing for different API keys to be used in future
Fixes #741 