### PR TITLE
Fixed #727 on C016

### DIFF
--- a/mapcomposer/app/applications/he/static/script/plugins/FeatureManagerWMSHighLight.js
+++ b/mapcomposer/app/applications/he/static/script/plugins/FeatureManagerWMSHighLight.js
@@ -33,8 +33,8 @@ Ext.namespace('gxp.he');
 /** api: constructor
  *  .. class:: FeatureManagerWMSHighLight(config)
  *  This class add wms highligth capability to FeatureManager plugin.
- *  
- */   
+ *
+ */
 gxp.plugins.FeatureManagerWMSHighLight = Ext.extend(gxp.plugins.FeatureManager, {
  /** api: ptype = gxp_featuremanagerwmshighlight */
     ptype: "gxp_featuremanagerwmshighlight",
@@ -44,7 +44,7 @@ gxp.plugins.FeatureManagerWMSHighLight = Ext.extend(gxp.plugins.FeatureManager, 
      *    feature
      */
     highLightLayer: null,
-    
+
     /** api: config[wmsHighLight]
      *  ``Boolean`` If true will show wms layer with highlighted features
      *    feature
@@ -52,7 +52,7 @@ gxp.plugins.FeatureManagerWMSHighLight = Ext.extend(gxp.plugins.FeatureManager, 
     wmsHighLight:true,
 
     /** api: config[strWithHighLight]
-     *  ``String`` 
+     *  ``String``
      *    default string to identify highlight styles.
      */
     strWithHighLight:"_highlight",
@@ -79,8 +79,8 @@ gxp.plugins.FeatureManagerWMSHighLight = Ext.extend(gxp.plugins.FeatureManager, 
      */
     init: function(target) {
         gxp.plugins.FeatureManagerWMSHighLight.superclass.init.apply(this, arguments);
-        
-        
+
+
         this.on({
             //TODO add a beforedestroy event to the tool
             beforedestroy: function() {
@@ -92,11 +92,10 @@ gxp.plugins.FeatureManagerWMSHighLight = Ext.extend(gxp.plugins.FeatureManager, 
 
                     var layer=this.layerRecord.get("layer");
                     if(!this.highLightLayer) this.createHighLightLayer(layer);
-                        else if(this.highLightLayer.name!=layer.name){
+                    else if(this.highLightLayer.name!=layer.name){
                             this.destroyHighLightLayer();
                             this.createHighLightLayer(layer);
                         }
-                    
                     var protocol=store.proxy.protocol;
                     var format= new OpenLayers.Format.Filter({ ////new OpenLayers.Format.CQL();
                             version: protocol.version,
@@ -105,7 +104,7 @@ gxp.plugins.FeatureManagerWMSHighLight = Ext.extend(gxp.plugins.FeatureManager, 
                     var qfilter=new OpenLayers.Format.XML().write(format.write(filter));
                     var highlightStyle=this.hasHighLightStyle(this.layerRecord);
                     if(!highlightStyle){
-                    	var sld = {version: "1.0.0", namedLayers: {}};                 
+                    	var sld = {version: "1.0.0", namedLayers: {}};
                     	var name = this.layerRecord.data.name;
                     	sld.namedLayers[name] = {name: name, userStyles: []};
                     	var symbolizer = this.selectionSymbolizer;
@@ -121,19 +120,21 @@ gxp.plugins.FeatureManagerWMSHighLight = Ext.extend(gxp.plugins.FeatureManager, 
                          symbolizer = {Polygon: this.selectionSymbolizer['Polygon']};
                     	}
                    		sld.namedLayers[name].userStyles.push({name: 'default', rules: [
-                        new OpenLayers.Rule({symbolizer: symbolizer 
+                        new OpenLayers.Rule({symbolizer: symbolizer
                        //, maxScaleDenominator: this.featureLayer.minScale
                         })
                     	]});
                     	var sldDescriptor = new OpenLayers.Format.SLD({srsName: protocol.srsName}).write(sld);
-                    	this.highLightLayer.mergeNewParams({SLD_BODY: sldDescriptor,FILTER:qfilter,STYLES:null});
+                    	if(this.highLightLayer.vendorParams)this.highLightLayer.vendorParams.cql_filter=null;
+                        this.highLightLayer.mergeNewParams({SLD_BODY: sldDescriptor,FILTER:qfilter,STYLES:null,CQL_FILTER:null});
                 	}else{
-                		this.highLightLayer.mergeNewParams({STYLES: highlightStyle,FILTER:qfilter});
+                        if(this.highLightLayer.vendorParams)this.highLightLayer.vendorParams.cql_filter=null;
+                		this.highLightLayer.mergeNewParams({STYLES: highlightStyle,FILTER:qfilter,CQL_FILTER:null});
                 	}
-                    
+
 
                     if(!this.highLightLayer.map) layer.map.addLayer(this.highLightLayer);
-                    
+
                         this.highLightLayer.setVisibility(this.visible());
 
             }
@@ -161,8 +162,8 @@ gxp.plugins.FeatureManagerWMSHighLight = Ext.extend(gxp.plugins.FeatureManager, 
         if (source && source instanceof gxp.plugins.WMSSource) {
             source.getSchema(record, function(schema) {
                 if (schema === false) {
-                
-                    //information about why selected layers are not queriable.                
+
+                    //information about why selected layers are not queriable.
                     var layer = record.get("layer");
                     var wmsVersion = layer.params.VERSION;
                     Ext.MessageBox.show({
@@ -172,7 +173,7 @@ gxp.plugins.FeatureManagerWMSHighLight = Ext.extend(gxp.plugins.FeatureManager, 
                         animEl: 'elId',
                         icon: Ext.MessageBox.INFO
                     });
-                    
+
                     this.clearFeatureStore();
                 } else {
                     var fields = [], geometryName,propertyNames=[];
@@ -209,8 +210,8 @@ gxp.plugins.FeatureManagerWMSHighLight = Ext.extend(gxp.plugins.FeatureManager, 
                             propertyNames.push(r.get("name"));
                         }
                     }, this);
-                    
-                    var protocolOptions = {    
+
+                    var protocolOptions = {
                         srsName: this.target.mapPanel.map.getProjection(),
                         url: schema.url,
                         featureType: schema.reader.raw.featureTypes[0].typeName,
@@ -232,7 +233,7 @@ gxp.plugins.FeatureManagerWMSHighLight = Ext.extend(gxp.plugins.FeatureManager, 
                         resultType: "hits",
                         filter: filter
                     }, protocolOptions));
-                    
+
                     this.featureStore = new gxp.data.WFSFeatureStore(Ext.apply({
                         fields: fields,
                         proxy: {
@@ -241,7 +242,7 @@ gxp.plugins.FeatureManagerWMSHighLight = Ext.extend(gxp.plugins.FeatureManager, 
                                 propertyNames: (this.disableGeometry)? propertyNames:[]
                             }
                         },
-                        
+
                         maxFeatures: this.maxFeatures,
                         layer: this.featureLayer,
                         ogcFilter: filter,
@@ -265,11 +266,11 @@ gxp.plugins.FeatureManagerWMSHighLight = Ext.extend(gxp.plugins.FeatureManager, 
         } else {
             this.clearFeatureStore();
             this.fireEvent("layerchange", this, record, false);
-        }        
+        }
     },
 
      /** private: method[setLayerDisplay]
-     *  
+     *
      */
     setLayerDisplay: function() {
     	gxp.plugins.FeatureManagerWMSHighLight.superclass.setLayerDisplay.apply(this, arguments);
@@ -334,14 +335,14 @@ gxp.plugins.FeatureManagerWMSHighLight = Ext.extend(gxp.plugins.FeatureManager, 
     		var styles = sourceLayer.get('styles');
     	    if(styles){
                 for (var key in styles){
-                    if(styles.hasOwnProperty(key)){                    
+                    if(styles.hasOwnProperty(key)){
                         var obj = styles[key];
                         var sld = obj.name.search(this.strWithHighLight);
                         if(sld != -1)
-                            return obj.name;                                
-                         
+                            return obj.name;
+
                         }
-                    }    
+                    }
                 }
              return undefined;
 

--- a/mapcomposer/app/static/externals/gxp/src/script/plugins/SpatialSelectorQueryForm.js
+++ b/mapcomposer/app/static/externals/gxp/src/script/plugins/SpatialSelectorQueryForm.js
@@ -40,23 +40,23 @@ Ext.namespace("gxp.plugins");
  *    Plugin for performing queries on feature layers with a pluggable spatial selector
  */
 gxp.plugins.SpatialSelectorQueryForm = Ext.extend(gxp.plugins.QueryForm, {
-    
+
     /** api: ptype = gxp_querybboxform */
     ptype: "gxp_spatialqueryform",
-    
+
     filterMapText: 'Filter Map',
-    
+
     noFilterSelectedMsgTitle: "No filter selected",
-    
+
     noFilterSelectedMsgText: "You must select at least one filter",
-    
+
     invalidRegexFieldMsgTitle: "Invalid Fields",
-    
-    invalidRegexFieldMsgText: "One or more fields are incorrect!",    
-    
+
+    invalidRegexFieldMsgText: "One or more fields are incorrect!",
+
     /** api: config[spatialSelectorsConfig]
      * ``Object``
-     * Spatial selector pluggins configurations. 
+     * Spatial selector pluggins configurations.
      * @see gxp.plugins.spatialselector.SpatialSelectorMethod.js
      */
     spatialSelectorsConfig:{
@@ -74,29 +74,39 @@ gxp.plugins.SpatialSelectorQueryForm = Ext.extend(gxp.plugins.QueryForm, {
             ptype : 'gxp_spatial_polygon_selector'
         }
     },
-    
+
     /** api: config[filterLayer]
      * ``Object``
      * Add controls to filter WMS layer using the filter
      */
     filterLayer: true,
-    
+
     /** api: config[validators]
      * ``Object``
      * Add regex validator
-     */    
+     */
     validators: {},
-    
+
     /** api: config[autoComplete]
      * ``Object``
      * Adds autocomplete support for text fields, allows specifying the sources that support autocomplete.
-     */    
+     */
     autoComplete: null,
-    
+
+     /** private: property[origLayersFilter]
+     *  ``Objets`` Save the original state of cql and ogc layer filter
+     *    i.e. { layerName : {
+     *               cql_filte :""
+     *               filter:""
+     *           }}
+     *
+     */
+    origLayersFilter: null,
+
     init: function(target) {
-        
+
         var me = this;
-      
+        this.origLayersFilter={};
         if(!this.style){
             this.style = new OpenLayers.Style();
             if(this.outputConfig){
@@ -122,19 +132,19 @@ gxp.plugins.SpatialSelectorQueryForm = Ext.extend(gxp.plugins.QueryForm, {
             },
             spatialSelectorsConfig: spatialSelectorsConfig
         });
-       
+
         return gxp.plugins.SpatialSelectorQueryForm.superclass.init.apply(this, arguments);
     },
 
     getFormId: function(){
         return this.id + "_spatialQueryForm";
     },
-    
+
     /** api: method[addOutput]
      */
     addOutput: function(config) {
         this.featureManagerTool = this.target.tools[this.featureManager];
-		
+
 		var me = this;
 
         var spatialSelector = this.spatialSelector;
@@ -146,37 +156,37 @@ gxp.plugins.SpatialSelectorQueryForm = Ext.extend(gxp.plugins.QueryForm, {
             bbarButtons.push({
                 text: this.filterMapText,
                 iconCls: "gxp-icon-map-filter",
-                handler: function() {					
+                handler: function() {
                     // Collect all selected filters
                     var filters = new Array();
-                    
+
                     if(queryForm.spatialSelectorFieldset && !queryForm.spatialSelectorFieldset.collapsed){
-                        var currentFilter = this.spatialSelector.getQueryFilter();   
+                        var currentFilter = this.spatialSelector.getQueryFilter();
                         if (currentFilter) {
                             //convert filter into native srs
                             //get native srs
                             var rec  = this.featureManagerTool.layerRecord;
                             var bbox = rec.get('bbox');
-                         
+
                             var nativeSRS;
-                            for(var c in bbox) {                                
+                            for(var c in bbox) {
                                 if(c && c.indexOf('EPSG')==0) nativeSRS = c;
                             }
-                            
+
                             currentFilter = currentFilter.clone();
                             currentFilter.value.transform(this.target.mapPanel.map.getProjectionObject(),new OpenLayers.Projection(nativeSRS));
-                            
+
                             filters.push(currentFilter);
                         }
                     }
 
                     if(queryForm.filterBuilder && !queryForm.filterBuilder.collapsed){
                         var attributeFilter = queryForm.filterBuilder.getFilter();
-                        
+
                         //TODO replace * with % in strings
                         if(attributeFilter){
                             var attributeFilter = attributeFilter.clone();
-                            
+
                             //inspect tree of filters
                             var replaceLikeStrings = function(node,oldc,newc){
                                 var oldc = oldc || '*';
@@ -188,23 +198,23 @@ gxp.plugins.SpatialSelectorQueryForm = Ext.extend(gxp.plugins.QueryForm, {
                                 }else if (node.type== "~"){
                                     //replace all
                                     node.value = node.value.split(oldc).join(newc);
-                                    
+
                                 }
                             }
-                            
+
                             replaceLikeStrings(attributeFilter);
-                            
+
                         }
-                        
+
                         attributeFilter && filters.push(attributeFilter);
                     }
 
-                    if(filters.length > 0){                         
+                    if(filters.length > 0){
                          var filter =  filters.length > 1 ? new OpenLayers.Filter.Logical({
                                 type: OpenLayers.Filter.Logical.AND,
                                 filters: filters
                             }) : filters[0];
-                        
+
                             if(this.target.tools.layertree_plugin){
                                 var selmodel = this.target.tools.layertree_plugin.output[0].selModel;
                                 var node =selmodel.getSelectedNode();
@@ -213,36 +223,36 @@ gxp.plugins.SpatialSelectorQueryForm = Ext.extend(gxp.plugins.QueryForm, {
                             if(!this.featureManagerTool.layerRecord.getLayer().vendorParams){
                                 this.featureManagerTool.layerRecord.getLayer().vendorParams = {};
                             }
-                            this.featureManagerTool.layerRecord.getLayer().mergeNewParams({cql_filter:filter.toString()}); 
+                            this.featureManagerTool.layerRecord.getLayer().mergeNewParams({cql_filter:filter.toString()});
                             this.featureManagerTool.layerRecord.getLayer().vendorParams.cql_filter = filter.toString();
                     }else{
-                        var layer = this.featureManagerTool.layerRecord.getLayer(); 
+                        var layer = this.featureManagerTool.layerRecord.getLayer();
                         delete layer.params.CQL_FILTER;
                         layer.redraw();
                     }
-                      
+
                 },
                 scope: this
             });
         }
 
         bbarButtons.push("->");
-        bbarButtons.push({   
-            scope: this,    
+        bbarButtons.push({
+            scope: this,
             text: this.cancelButtonText,
             iconCls: "cancel",
-            handler: function() {                
+            handler: function() {
                 this.resetFeatureManager();
                 this.spatialSelector.reset();
 
 				this.spatialSelector.selectionMethodCombo.reset();
-				
+
                 var methodSelection = this.output[0].outputType;
 
                 if (me.draw) {me.draw.deactivate();};
                 if (me.drawings) {me.drawings.destroyFeatures();};
                 if (me.filterCircle) {me.filterCircle = new OpenLayers.Filter.Spatial({});};
-                if (me.filterPolygon) {me.filterPolygon = new OpenLayers.Filter.Spatial({});};    
+                if (me.filterPolygon) {me.filterPolygon = new OpenLayers.Filter.Spatial({});};
 
                 var ownerCt = this.outputTarget ? queryForm.ownerCt :
                     queryForm.ownerCt.ownerCt;
@@ -252,23 +262,28 @@ gxp.plugins.SpatialSelectorQueryForm = Ext.extend(gxp.plugins.QueryForm, {
                     this.addFilterBuilder(
                         this.featureManagerTool, this.featureManagerTool.layerRecord,
                         this.featureManagerTool.schema
-                    ); 
-                }      
-                
+                    );
+                }
+
                 if(me.filterLayer){
-                    var layer = this.featureManagerTool.layerRecord.getLayer(); 
-                     delete layer.params.CQL_FILTER;
-                     delete layer.vendorParams.cql_filter;
-                    
+                    var layer = this.featureManagerTool.layerRecord.getLayer();
+                     if(me.origLayersFilter[layer.name]){
+                        layer.mergeNewParams({cql_filter:me.origLayersFilter[layer.name].cql_filter}),
+                        layer.vendorParams.cql_filter=me.origLayersFilter[layer.name].cql_filter;
+                     }else
+                     {
+                        delete layer.params.CQL_FILTER;
+                        delete layer.vendorParams.cql_filter;
+                     }
                      if(this.target.tools.layertree_plugin){
                          var selmodel = this.target.tools.layertree_plugin.output[0].selModel;
                          var node =selmodel.getSelectedNode();
                          node.setIconCls('gx-tree-layer-icon');
                      }
-                    
+
                      layer.redraw();
                  }
-                
+
                  spatialSelector.filterGeometryName = this.featureStore
                      && this.featureStore.geometryName
                      ? this.featureManagerTool.featureStore.geometryName : this.featureManagerTool.featureStore.geometryName;
@@ -304,13 +319,13 @@ gxp.plugins.SpatialSelectorQueryForm = Ext.extend(gxp.plugins.QueryForm, {
                         if(!validateItem.isValid(true)){
                             invalidItems++;
                         }
-                    }                        
+                    }
                     f++;
                 }
                 //END
 
                 if(queryForm.spatialSelectorFieldset && !queryForm.spatialSelectorFieldset.collapsed){
-                    var currentFilter = this.spatialSelector.getQueryFilter();   
+                    var currentFilter = this.spatialSelector.getQueryFilter();
                     if (currentFilter) {
                         filters.push(currentFilter);
                     }
@@ -322,18 +337,18 @@ gxp.plugins.SpatialSelectorQueryForm = Ext.extend(gxp.plugins.QueryForm, {
                 }
 
                 // //////////////////////////////////////////////
-                // Finally check for any other existing filters 
-                // (i.e. 'cql_filter') defined by other plugins. 
+                // Finally check for any other existing filters
+                // (i.e. 'cql_filter') defined by other plugins.
                 // //////////////////////////////////////////////
                 var layerRecord = this.featureManagerTool.layerRecord;
                 var layer = layerRecord.getLayer();
 
                 var pluginFilter;
-                if(layer && layer.vendorParams){        
+                if(layer){
                     var pFilters = [];
 
                     // Check for cql_filter
-                    var pluginCqlFilter = layer.vendorParams.cql_filter;
+                    var pluginCqlFilter = this.origLayersFilter[layer.name].cql_filter;
                     if(pluginCqlFilter){
                         var cqlFormat = new OpenLayers.Format.CQL();
                         try{
@@ -343,9 +358,8 @@ gxp.plugins.SpatialSelectorQueryForm = Ext.extend(gxp.plugins.QueryForm, {
                             invalidItems++;
                         }
                     }
-
                     // Check for OGC XML filter
-                    var pluginXMLOGCFilter = layer.vendorParams.filter;
+                    var pluginXMLOGCFilter = this.origLayersFilter[layer.name].filter;
                     if(pluginXMLOGCFilter){
                         var ogcFormat = new OpenLayers.Format.Filter();
                         try{
@@ -362,11 +376,11 @@ gxp.plugins.SpatialSelectorQueryForm = Ext.extend(gxp.plugins.QueryForm, {
                             filters: pFilters
                         });
                     }
-                    
+
                     // /////////////////////////////////////////////////
-                    // Set or refresh viewparams in featureManager 
+                    // Set or refresh viewparams in featureManager
                     // /////////////////////////////////////////////////
-                    if(layer.vendorParams.viewparams){
+                    if(layer.vendorParams && layer.vendorParams.viewparams){
                         this.featureManagerTool.featureStore.setViewParams(layer.vendorParams.viewparams);
                         this.featureManagerTool.hitCountProtocol.viewparams = layer.vendorParams.viewparams;
                         this.featureManagerTool.hitCountProtocol.options.viewparams = layer.vendorParams.viewparams;
@@ -385,14 +399,14 @@ gxp.plugins.SpatialSelectorQueryForm = Ext.extend(gxp.plugins.QueryForm, {
                                 filters: filters
                             }) :
                             filters[0]
-                        );    
+                        );
                     }else{
                         Ext.Msg.show({
                             title: this.noFilterSelectedMsgTitle,
                             msg: this.noFilterSelectedMsgText,
                             buttons: Ext.Msg.OK,
                             icon: Ext.MessageBox.ERROR
-                        }); 
+                        });
                     }
                 }else{
                     Ext.Msg.show({
@@ -406,7 +420,7 @@ gxp.plugins.SpatialSelectorQueryForm = Ext.extend(gxp.plugins.QueryForm, {
             },
             scope: this
         });
-        
+
         config = Ext.apply({
             border: false,
             bodyStyle: "padding: 10px",
@@ -451,16 +465,24 @@ gxp.plugins.SpatialSelectorQueryForm = Ext.extend(gxp.plugins.QueryForm, {
             },this.outputConfig.attributeFieldset||{})],
             bbar: bbarButtons
         }, config || {});
-		
-        var queryForm = gxp.plugins.QueryForm.superclass.addOutput.call(this, config);        
+
+        var queryForm = gxp.plugins.QueryForm.superclass.addOutput.call(this, config);
         var methodSelection = this.output[0].outputType;
-        
-        this.addFilterBuilder = function(mgr, rec, schema) {			
+
+        this.addFilterBuilder = function(mgr, rec, schema) {
+
+            var layer=(mgr.layerRecord)? mgr.layerRecord.get("layer"):null;
+            if( layer && ! me.origLayersFilter[layer.name]){
+                 me.origLayersFilter[layer.name]={
+                    cql_filter: (layer.vendorParams && layer.vendorParams.cql_filter)? layer.vendorParams.cql_filter:null,
+                    filter: (layer.vendorParams && layer.vendorParams.filter)? layer.vendorParams.filter:null
+                 }
+            }
             // is current source enabled for autoComplete ?
             var autoComplete = rec && me.autoComplete && me.autoComplete.sources && me.autoComplete.sources.indexOf(rec.get('source')) !== -1;
             queryForm.attributeFieldset.removeAll();
             queryForm.setDisabled(!schema);
-			
+
             if (schema) {
                 queryForm.attributeFieldset.add({
                     xtype: "gxp_filterbuilder",
@@ -474,7 +496,7 @@ gxp.plugins.SpatialSelectorQueryForm = Ext.extend(gxp.plugins.QueryForm, {
                 });
 				me.filterBuilder = queryForm.filterBuilder;
 			   /**
-				* Overriding the removeCondition method in order to manage the 
+				* Overriding the removeCondition method in order to manage the
 				* single filterfield reset.
 				*/
 				queryForm.filterBuilder.removeCondition = function(item, filter) {
@@ -484,13 +506,13 @@ gxp.plugins.SpatialSelectorQueryForm = Ext.extend(gxp.plugins.QueryForm, {
 						this.childFilterContainer.remove(item, true);
 					}else{
 						var items = item.findByType("gxp_filterfield");
-						
+
 						var i = 0;
 						while(items[i]){
 							items[i].reset();
-							
+
                             for(var c = 1;c<items[i].items.items.length;c++){
-                                items[i].items.get(c).disable();                            
+                                items[i].items.get(c).disable();
                             }
 
 							filter.value = null;
@@ -499,10 +521,10 @@ gxp.plugins.SpatialSelectorQueryForm = Ext.extend(gxp.plugins.QueryForm, {
 							i++;
 						}
 					}
-					
+
 					this.fireEvent("change", this);
 				};
-                
+
                 queryForm.filterBuilder.reset = function() {
 					var parent = this.filter.filters[0].filters;
                     var items = this.findByType("gxp_filterfield");
@@ -513,12 +535,12 @@ gxp.plugins.SpatialSelectorQueryForm = Ext.extend(gxp.plugins.QueryForm, {
                             this.childFilterContainer.remove(item.ownerCt, true);
                         } else {
                             item.reset();
-							
+
                             for(var c = 1;c<item.items.items.length;c++){
                                 if(item.items.get(c) instanceof Ext.Container) {
                                     item.items.get(c).removeAll();
                                 } else {
-                                    item.items.get(c).disable();                            
+                                    item.items.get(c).disable();
                                 }
                             }
                             var filter = item.filter;
@@ -527,36 +549,36 @@ gxp.plugins.SpatialSelectorQueryForm = Ext.extend(gxp.plugins.QueryForm, {
                             filter.upperBoundary = null;
                         }
                     }
-                    
+
 					this.fireEvent("change", this);
 				};
-				
+
 				if (me.draw) {me.draw.deactivate();};
 				if (me.drawings) {me.drawings.destroyFeatures();};
 				if (me.filterCircle) {me.filterCircle = new OpenLayers.Filter.Spatial({});};
-				if (me.filterPolygon) {me.filterPolygon = new OpenLayers.Filter.Spatial({});};   
+				if (me.filterPolygon) {me.filterPolygon = new OpenLayers.Filter.Spatial({});};
             } else {
                 me.spatialSelector.reset();
-				
+
 				if (me.draw) {me.draw.deactivate();};
 				if (me.drawings) {me.drawings.destroyFeatures();};
 				if (me.filterCircle) {me.filterCircle = new OpenLayers.Filter.Spatial({});};
-				if (me.filterPolygon) {me.filterPolygon = new OpenLayers.Filter.Spatial({});};  
+				if (me.filterPolygon) {me.filterPolygon = new OpenLayers.Filter.Spatial({});};
             }
-			
+
             queryForm.attributeFieldset.doLayout();
-        
+
             spatialSelector.filterGeometryName = this.featureStore
                 && this.featureStore.geometryName
                 ? this.featureStore.geometryName : null;
         };
-		
+
         this.featureManagerTool.on("layerchange", this.addFilterBuilder);
-		
+
         this.addFilterBuilder(this.featureManagerTool,
             this.featureManagerTool.layerRecord, this.featureManagerTool.schema
         );
-		
+
         this.featureManagerTool.on({
             "beforequery": function() {
                 new Ext.LoadMask(queryForm.getEl(), {
@@ -581,7 +603,7 @@ gxp.plugins.SpatialSelectorQueryForm = Ext.extend(gxp.plugins.QueryForm, {
             },
             scope: this
         });
-        
+
         return queryForm;
     }
 });


### PR DESCRIPTION
Spatial selector now saves the original state of cql_filter and filter parameters. When query panel is resected we restore original state in the wms layer.