### PR TITLE
configurable wfs basepath

### DIFF
--- a/mapcomposer/app/static/externals/gxp/src/script/plugins/SpatialSelectorQueryForm.js
+++ b/mapcomposer/app/static/externals/gxp/src/script/plugins/SpatialSelectorQueryForm.js
@@ -500,7 +500,9 @@ gxp.plugins.SpatialSelectorQueryForm = Ext.extend(gxp.plugins.QueryForm, {
             if (rec && rec.data.group != 'background' && !schema && rec.owsType == "WFS") {
                 queryForm.getEl().mask(mgr.noValidWmsVersionMsgText + rec.get('layer').params.VERSION);
             } else if (rec && rec.data.group != 'background' && !schema && rec.error) {
-                queryForm.getEl().mask(rec.error);
+                if (queryForm.getEl()) {
+                    queryForm.getEl().mask(rec.error);
+                }
             }
 
             if (schema) {

--- a/mapcomposer/app/static/externals/gxp/src/script/plugins/WMSSource.js
+++ b/mapcomposer/app/static/externals/gxp/src/script/plugins/WMSSource.js
@@ -154,7 +154,7 @@ gxp.plugins.WMSSource = Ext.extend(gxp.plugins.LayerSource, {
 	errorTitle: "Error",
 
     showGetSchemaError: true,
-
+    wfsBase: null,
     /** api: method[createStore]
      *
      *  Creates a store of layer records.  Fires "ready" when store is loaded.
@@ -736,7 +736,7 @@ gxp.plugins.WMSSource = Ext.extend(gxp.plugins.LayerSource, {
                     }
                 } else {
                     schema = new GeoExt.data.AttributeStore({
-                        url: r.get("owsURL"),
+                        url: this.wfsBase || r.get("owsURL"),
                         baseParams: {
                             SERVICE: "WFS",
                             //TODO should get version from WFS GetCapabilities


### PR DESCRIPTION
gxp_wmssource accepts `wfsBase` option to define an alternative
wfs service path.

    [...]
    "wms_source": {
        "ptype": "gxp_wmssource",
        [...]
        "wfsBase": "http://some.domain/wfs?",
        [...]
    }
    [...]