### PR TITLE
Load ux.js before gxp.js Fixes #767

### DIFF
--- a/mapcomposer/app/templates/viewer.html
+++ b/mapcomposer/app/templates/viewer.html
@@ -19,9 +19,10 @@
         <link rel="stylesheet" type="text/css" href="externals/GeoExt/resources/css/gxtheme-gray.css">
         <script type="text/javascript" src="script/GeoExt.js"></script> 
 
-		<!-- canvg-1.2 resources -->
-		<script type="text/javascript" src="script/canvg-1.2.js"></script> 
-		
+        <!-- canvg-1.2 resources -->
+        <script type="text/javascript" src="script/canvg-1.2.js"></script>
+
+        <script type="text/javascript" src="script/ux.js"></script>
         <!-- gxp resources -->
         <link rel="stylesheet" type="text/css" href="externals/gxp/src/theme/all.css">
         <script type="text/javascript" src="script/gxp.js"></script> 
@@ -32,7 +33,7 @@
         <!--[if IE]><link rel="stylesheet" type="text/css" href="theme/app/ie.css"/><![endif]-->        
 
         <script type="text/javascript" src="script/GeoExplorer.js"></script>
-        <script type="text/javascript" src="script/ux.js"></script>
+
         
         <!-- geocoding data  -->
         <script type="text/javascript" src="data/georeferences.js"></script>


### PR DESCRIPTION
gxp.js depends on ux.js, so it is now loaded after it.