### PR TITLE
Close task 2 of GeoWeb Phase III document.

### DIFF
--- a/mapcomposer/app/applications/he/buildjs.cfg
+++ b/mapcomposer/app/applications/he/buildjs.cfg
@@ -1,28 +1,28 @@
 [ie8_compat.js]
 root = static/script
-include = 
+include =
     libs/excanvas.min.js
-    
+
 [r2d3.js]
 root = static/script
-include = 
+include =
     libs/r2d3.min.js
     libs/aight.min.js
     libs/es5-sham.min.js
 
 [d3.js]
 root = static/script
-include = 
+include =
     libs/d3.min.js
 
 [c3.js]
 root = static/script
-include = 
+include =
     libs/jquery-1.11.1.min.js
     libs/c3.min.js
     widgets/charts/C3Chart.js
     widgets/charts/ChartPanel.js
-    
+
 [mg.js]
 root = static/script
 include =
@@ -32,19 +32,19 @@ include =
 
 [dc.js]
 root = static/script
-include = 
+include =
     libs/crossfilter.min.js
     libs/dc.min.js
     widgets/charts/DCChart.js
     widgets/charts/ChartPanel.js
-    
+
 [chartjs.js]
 root = static/script
-include = 
+include =
     libs/Chart.min.js
     widgets/charts/ChartJsChart.js
     widgets/charts/ChartPanel.js
-    
+
 [gcd.js]
 root = static/script
 include =
@@ -60,6 +60,7 @@ include =
     widgets/grid/ContractExpirationsGrid.js
     widgets/grid/ScheduledCapacitiesGrid.js
     widgets/form/UserGroupMultiSelect.js
+    widgets/form/MapsComboBox.js
     widgets/grid/HeFeatureGrid.js
     widgets/WMSLayerPanelHE.js
     widgets/WMSStylesDialogHE.js
@@ -75,7 +76,12 @@ include =
     plugins/WMSRasterStylesDialogHE.js
     plugins/StylerHE.js
     plugins/StyleWriterHE.js
+    plugins/MapSelector.js
     GCDViewer.js
     plugins/PrintSnapshotHE.js
     plugins/GeoStoreStyleWriter.js
-    
+
+[hemanager.js]
+root = static/script
+include =
+    widgets/form/MapsComboBox.js

--- a/mapcomposer/app/applications/he/config.js
+++ b/mapcomposer/app/applications/he/config.js
@@ -2,6 +2,7 @@ exports.config = function(urls, middleware) {
     urls[0] = [(/^\/(index(.html)?)?/), require("./loginpage").app];
     urls[1] = [(/^\/(loginpage(.html)?)/), require("./loginpage").app];
     urls[2] = [(/^\/(composer)/), require("./composer").app];
+    urls[3] = [(/^\/(manager(.html)?)?/), require("./manager").app];
     urls.push([(/^\/(gcd(.html)?)/), require("./gcd").app]);
     middleware.unshift(require("ringo/middleware/static").middleware({base: module.resolve("static")}));
 };

--- a/mapcomposer/app/applications/he/manager.js
+++ b/mapcomposer/app/applications/he/manager.js
@@ -1,0 +1,18 @@
+var Response = require("ringo/webapp/response").Response;
+var Request = require("ringo/webapp/request").Request;
+var auth = require("../../auth");
+
+exports.app = function(req) {
+    var request = new Request(req);
+    var details = auth.getDetails(request);
+
+	if(request.isPost){
+		var content = JSON.stringify(request.postParams);
+		print("Post Content is : " + content);
+		var response = Response.skin(module.resolve("templates/manager.html"), {status: details.status || 404, content: content});
+	}else{
+		var response = Response.skin(module.resolve("templates/manager.html"), {status: details.status || 404, content: "{}"});
+	}
+
+	return response;
+};

--- a/mapcomposer/app/applications/he/static/config/login.js
+++ b/mapcomposer/app/applications/he/static/config/login.js
@@ -354,7 +354,8 @@
             "target":"paneltbar",
             "index":5
           }
-      }, {
+      },
+      {
             "ptype": "gxp_help",
             "actionTarget": "paneltbar",
             "text": "Help",
@@ -442,6 +443,11 @@
         },
         {
           "ptype":"gxp_onpageunloadalert"
+        },
+        {
+          "ptype": "gxp_mapselector",
+          "outputTarget":"paneltbar",
+          "idx":24
         }
 
     ]

--- a/mapcomposer/app/applications/he/static/config/managerConfig.js
+++ b/mapcomposer/app/applications/he/static/config/managerConfig.js
@@ -116,6 +116,14 @@
                 "value": ""
 
             },{
+                "xtype": "gxp_mapscombobox",
+                "anchor":"90%",
+                "id": "attribute.default_map",
+                "maxLength":255,
+                "fieldLabel": "Default Map",
+                "value": "",
+                "tpl": '<tpl for="."><tpl if="values.owner===\'admin\'"><div class="x-combo-list-item">{name}</div></tpl></tpl>'
+              },{
                 "xtype": "textarea",
                 "anchor":"90%",
                 "id": "notes",

--- a/mapcomposer/app/applications/he/static/css/gcd.css
+++ b/mapcomposer/app/applications/he/static/css/gcd.css
@@ -193,3 +193,9 @@ span.icon_span{
 .x-layout-collapsed.x-layout-collapsed-north, .x-layout-collapsed.x-layout-collapsed-south {
   height: 24px !important;
 }
+.map_add {
+  background-image: url(../externals/mapmanager/theme/img/map_add.png) !important;
+}
+.map_delete {
+    background-image: url(../externals/mapmanager/theme/img/map_delete.png) !important;
+}

--- a/mapcomposer/app/applications/he/static/hetranslations/de.js
+++ b/mapcomposer/app/applications/he/static/hetranslations/de.js
@@ -22,7 +22,7 @@ GeoExt.Lang.add("de", {
         gsGetPermissionError:"Nicht in der Lage, die Ressourcenberechtigungen abrufen."
     },
     "gxp.plugins.PrintSnapshotHE.prototype" :{
-        noSupportedLayersErrorMsg: " ist nicht zum Drucken zur Verfügung.<br/>Bitte wählen Sie eine der folgenden Optionen als Hintergrundschicht und versuchen Sie es erneut:<br/>",    
+        noSupportedLayersErrorMsg: " ist nicht zum Drucken zur Verfügung.<br/>Bitte wählen Sie eine der folgenden Optionen als Hintergrundschicht und versuchen Sie es erneut:<br/>",
         suggestionLayersMsg: "-> OpenStreetMap <br/> -> MapQuest OpenStreetMap <br/> -> MapQuest Imagery"
     },
     "gxp.plugins.Print.prototype": {
@@ -30,11 +30,11 @@ GeoExt.Lang.add("de", {
     },
     "gxp.plugins.he.GeoStoreStyleWriter.prototype": {
         mainLoadingMask: "Warten Sie mal...",
-        geostoreStyleErrorTitle: "Fehler.",   
+        geostoreStyleErrorTitle: "Fehler.",
         geostoreStyleCreationErrorMsg: "Fehler beim Erstellen des GeoStore Stil.",
-        geostoreStyleUpdateErrorMsg: "Error updating geostore style.",    
+        geostoreStyleUpdateErrorMsg: "Error updating geostore style.",
         geostoreStyleSearchErrorMsg: "Fehler beim Aktualisieren GeoStore Stil.",
-        geostoreStyleDeleteSuccessMsg: "GeoStore Stil erfolgreich gelöscht.",    
+        geostoreStyleDeleteSuccessMsg: "GeoStore Stil erfolgreich gelöscht.",
         geostoreStyleDeleteErrorMsg: "GeoStore Stil nicht gelöscht."
     },
 
@@ -64,19 +64,52 @@ GeoExt.Lang.add("de", {
          stylesFieldsetTitle: "Stile",
          rulesFieldsetTitle: "Regeln",
          errorTitle: "Fehler beim Speichern Stil",
-         errorMsg: "Es gab einen Fehler beim Speichern des Stil zurück an den Server.",                 
+         errorMsg: "Es gab einen Fehler beim Speichern des Stil zurück an den Server.",
          searchStyleResourcesErrorTitle: "Fehler",
          searchStyleResourcesErrorMsg: "Da lief was falsch beim Laden von Stilen"
     },
-    
+
     "gxp.plugins.he.StylerHE.prototype": {
         menuText: "Style bearbeiten",
-        tooltip: "Layer Styles verwalten",    
+        tooltip: "Layer Styles verwalten",
         geostoreStyleCategoryCreatedSuccessTitle: "GeoStore Kategorie Schöpfung.",
         geostoreStyleCategoryCreatedSuccessMsg: "GeoStore LAYERS_STYLES Kategorie erfolgreich erstellt.",
         geostoreStyleCategoryCreatedErrorTitle: "Fehler beim Erstellen der Kategorie.",
         geostoreStyleCategoryCreatedErrorMsg: "GeoStore Ressourcen Behinderte, nur Admin kann fehlende LAYERS_STYLES Kategorie erstellen.",
         geostoreStyleCategorySearchErrorTitle: "Fehlersuche Kategorien.",
         geostoreStyleCategorySearchErrorMsg: "Etwas falsch in den Suchkategorien ging."
+    },
+
+    "gxp.form.MapsComboBox.prototype": {
+        fieldLabel: "User-Karten",
+        emptyText:"Karten",
+        valueNotFoundText: "Karten"
+    },
+
+    "gxp.plugins.he.MapSelector.prototype": {
+        mapActionText: "Karte Menü",
+        mapActionTip: "Karte Menü",
+        saveText: "Ersparen",
+        createText: "Erstellen",
+        deleteText: "Löschen",
+        contextSaveSuccessString: "Karte kontext erfolgreich gespeichert",
+        contextSaveFailString: "Karte kontext nicht erfolgreich gespeichert",
+        contextCreateSuccessString: "Karte erfolgreich erstellt",
+        contextCreateFailString: "Karte nicht erfolgreich erstellt",
+        contextDeleteSuccessString: "Karte erfolgreich gelöscht",
+        contextDeleteFailString: "Karte nicht erfolgreich gelöscht",
+        saveTitle: "Save Map Context?",
+        saveMsg: "Möchten Sie die Änderungen speichern möchten?",
+        createTitle: "Neue Karte erstellen?",
+        createMsg: "Möchten Sie Karte Kontext als neue Karte speichern?",
+        deleteTitle: "Karte löschen?",
+        deleteMsg: "Möchten Sie Ihre Karte löschen möchten?",
+        addResourceButtonText: "Hinzufügen Karte",
+        contextMsg: "Laden...",
+        mapMetadataTitle: "Legen Karte Metadaten",
+        mapMedatataSetTitle: "Karte Metadaten",
+        mapNameLabel: "Name",
+        mapDescriptionLabel: "Beschreibung",
+        conflictErrMsg: "Eine Karte mit dem gleichen Namen ist bereits vorhanden"
     }
 });

--- a/mapcomposer/app/applications/he/static/hetranslations/en.js
+++ b/mapcomposer/app/applications/he/static/hetranslations/en.js
@@ -20,9 +20,9 @@ GeoExt.Lang.add("en", {
         groupsLabel:"Groups",
         gsErrorTitle:"Geostore Error",
         gsGetPermissionError:"Unable to retrieve resource permissions."
-    },    
+    },
     "gxp.plugins.PrintSnapshotHE.prototype" :{
-        noSupportedLayersErrorMsg: " is not available for printing.<br/>Please select one of the following as your background layer and try again:<br/>",    
+        noSupportedLayersErrorMsg: " is not available for printing.<br/>Please select one of the following as your background layer and try again:<br/>",
         suggestionLayersMsg: "-> OpenStreetMap <br/> -> MapQuest OpenStreetMap <br/> -> MapQuest Imagery"
     },
     "gxp.plugins.Print.prototype": {
@@ -30,11 +30,11 @@ GeoExt.Lang.add("en", {
     },
     "gxp.plugins.he.GeoStoreStyleWriter.prototype": {
         mainLoadingMask: "Please wait...",
-        geostoreStyleErrorTitle: "Error.",   
+        geostoreStyleErrorTitle: "Error.",
         geostoreStyleCreationErrorMsg: "Error creating the geostore style.",
-        geostoreStyleUpdateErrorMsg: "Error updating geostore style.",    
+        geostoreStyleUpdateErrorMsg: "Error updating geostore style.",
         geostoreStyleSearchErrorMsg: "Failed to retrieve the geostore style.",
-        geostoreStyleDeleteSuccessMsg: "Geostore style successfully deleted.",    
+        geostoreStyleDeleteSuccessMsg: "Geostore style successfully deleted.",
         geostoreStyleDeleteErrorMsg: "Geostore Style not deleted."
     },
 
@@ -64,19 +64,53 @@ GeoExt.Lang.add("en", {
          stylesFieldsetTitle: "Styles",
          rulesFieldsetTitle: "Rules",
          errorTitle: "Error saving style",
-         errorMsg: "There was an error saving the style back to the server.",         
+         errorMsg: "There was an error saving the style back to the server.",
          searchStyleResourcesErrorTitle: "Error",
          searchStyleResourcesErrorMsg: "Something went wrong when loading styles"
     },
-    
+
     "gxp.plugins.he.StylerHE.prototype": {
         menuText: "Layer Styles",
-        tooltip: "Layer Styles",    
+        tooltip: "Layer Styles",
         geostoreStyleCategoryCreatedSuccessTitle: "Geostore Category creation.",
         geostoreStyleCategoryCreatedSuccessMsg: "Geostore LAYERS_STYLES Category successfully created.",
         geostoreStyleCategoryCreatedErrorTitle: "Error creating category.",
         geostoreStyleCategoryCreatedErrorMsg: "GeoStore resources disabled, only Admin can create missing LAYERS_STYLES CATEGORY.",
         geostoreStyleCategorySearchErrorTitle: "Error search categories.",
         geostoreStyleCategorySearchErrorMsg: "Something went wrong in the search categories."
+    },
+
+    "gxp.form.MapsComboBox.prototype": {
+        fieldLabel: "User maps",
+        emptyText:"Maps",
+        valueNotFoundText: "Maps"
+    },
+
+    "gxp.plugins.he.MapSelector.prototype": {
+        mapActionText: "Map Actions",
+        mapActionTip: "Map actions",
+        saveText: "Save",
+        createText: "Create",
+        deleteText: "Delete",
+        contextSaveSuccessString: "Map context saved succesfully",
+        contextSaveFailString: "Map context not saved succesfully",
+        contextCreateSuccessString: "Map created succesfully",
+        contextCreateFailString: "Map not created succesfully",
+        contextDeleteSuccessString: "Map deleted succesfully",
+        contextDeleteFailString: "Map not deleted succesfully",
+        saveTitle: "Save Map Context?",
+        saveMsg: "Would you like to save your changes?",
+        createTitle: "Create New Map?",
+        createMsg: "Would you like to save map context as new map?",
+        deleteTitle: "Delete Map?",
+        deleteMsg: "Would you like delete your map?",
+        addResourceButtonText: "Add Map",
+        contextMsg: 'Loading...',
+        mapMetadataTitle: "Insert Map Metadata",
+        mapMedatataSetTitle: "Map Metadata",
+        mapNameLabel: "Name",
+        mapDescriptionLabel: "Description",
+        conflictErrMsg: "A map with the same name already exists"
     }
+
 });

--- a/mapcomposer/app/applications/he/static/hetranslations/es.js
+++ b/mapcomposer/app/applications/he/static/hetranslations/es.js
@@ -20,9 +20,9 @@ GeoExt.Lang.add("es", {
         groupsLabel:"Grupos",
         gsErrorTitle:"Geostore Error",
         gsGetPermissionError:"No se puede recuperar permisos de recursos."
-    },    
+    },
     "gxp.plugins.PrintSnapshotHE.prototype" :{
-        noSupportedLayersErrorMsg: " no está disponible para la impresión.<br/>Por favor seleccione una de las siguientes como su capa de fondo y vuelva a intentarlo:<br/>",    
+        noSupportedLayersErrorMsg: " no está disponible para la impresión.<br/>Por favor seleccione una de las siguientes como su capa de fondo y vuelva a intentarlo:<br/>",
         suggestionLayersMsg: "-> OpenStreetMap <br/> -> MapQuest OpenStreetMap <br/> -> MapQuest Imagery"
     },
     "gxp.plugins.Print.prototype": {
@@ -30,11 +30,11 @@ GeoExt.Lang.add("es", {
     },
     "gxp.plugins.he.GeoStoreStyleWriter.prototype": {
         mainLoadingMask: "Por favor espera...",
-        geostoreStyleErrorTitle: "Error",   
+        geostoreStyleErrorTitle: "Error",
         geostoreStyleCreationErrorMsg: "Error al crear el estilo GeoStore",
-        geostoreStyleUpdateErrorMsg: "Error de actualización estilo GeoStore",    
+        geostoreStyleUpdateErrorMsg: "Error de actualización estilo GeoStore",
         geostoreStyleSearchErrorMsg: "No se pudo recuperar el estilo GeoStore",
-        geostoreStyleDeleteSuccessMsg: "Estilo GeoStore eliminado correctamente",    
+        geostoreStyleDeleteSuccessMsg: "Estilo GeoStore eliminado correctamente",
         geostoreStyleDeleteErrorMsg: "GeoStore estilo no elimina"
     },
 
@@ -64,11 +64,11 @@ GeoExt.Lang.add("es", {
          stylesFieldsetTitle: "Estilos",
          rulesFieldsetTitle: "Reglas",
          errorTitle: "Error estilo ahorro",
-         errorMsg: "Se ha producido un error al guardar el estilo de vuelta al servidor.",         
+         errorMsg: "Se ha producido un error al guardar el estilo de vuelta al servidor.",
          searchStyleResourcesErrorTitle: "Error",
          searchStyleResourcesErrorMsg: "Algo salió mal al cargar estilos"
     },
-    
+
     "gxp.he.WMSLayerPanelHE.prototype": {
         aboutText: "Información",
         titleText: "Título",
@@ -86,5 +86,38 @@ GeoExt.Lang.add("es", {
         loadMaskMsg: "Obteiniendo datos ...",
         noDataMsg: "No hay datos disponibles de la vistas actual",
         refreshText: "Refrescar"
+    },
+
+    "gxp.form.MapsComboBox.prototype": {
+        fieldLabel: "Mapas de los usuarios",
+        emptyText:"Mapas",
+        valueNotFoundText: "Mapas"
+    },
+
+    "gxp.plugins.he.MapSelector.prototype": {
+        mapActionText: "Mapa Acciones",
+        mapActionTip: "Mapa Acciones",
+        saveText: "Ahorrar",
+        createText: "Crear",
+        deleteText: "Borrar",
+        contextSaveSuccessString: "Contexto mapa guardado correctamente",
+        contextSaveFailString: "Contexto mapa no guardado correctamente",
+        contextCreateSuccessString: "Mapa creado con éxito",
+        contextCreateFailString: "Mapa no creado con éxito",
+        contextDeleteSuccessString: "Mapa eliminado correctamente",
+        contextDeleteFailString: "Mapa no eliminado correctamente",
+        saveTitle: "Guardar Mapa Contexto?",
+        saveMsg: "Quieres guardar los cambios?",
+        createTitle: "Crear Nuevo map?",
+        createMsg: "Quieres ahorrar mapa contexto como nuevo mapa?",
+        deleteTitle: "Eliminar mapa?",
+        deleteMsg: "Quieres eliminar el mapa?",
+        addResourceButtonText: "Añadir Mapa",
+        contextMsg: "Cargando...",
+        mapMetadataTitle: "Inserte Mapa Metadatos",
+        mapMedatataSetTitle: "Mapa Metadatos",
+        mapNameLabel: "Nombre",
+        mapDescriptionLabel: "Descripción",
+        conflictErrMsg: "Un mapa con el mismo nombre ya existe"
     }
 });

--- a/mapcomposer/app/applications/he/static/hetranslations/fr.js
+++ b/mapcomposer/app/applications/he/static/hetranslations/fr.js
@@ -20,9 +20,9 @@ GeoExt.Lang.add("fr", {
         groupsLabel:"Groupes",
         gsErrorTitle:"GeoStore Erreur",
         gsGetPermissionError:"Impossible de récupérer les autorisations de ressources."
-    },    
+    },
     "gxp.plugins.PrintSnapshotHE.prototype" :{
-        noSupportedLayersErrorMsg: " ne sont pas disponibles pour l'impression.<br/>S'il vous plaît sélectionnez une des options suivantes en tant que votre couche de fond et essayez à nouveau:<br/>",    
+        noSupportedLayersErrorMsg: " ne sont pas disponibles pour l'impression.<br/>S'il vous plaît sélectionnez une des options suivantes en tant que votre couche de fond et essayez à nouveau:<br/>",
         suggestionLayersMsg: "-> OpenStreetMap <br/> -> MapQuest OpenStreetMap <br/> -> MapQuest Imagery"
     },
     "gxp.plugins.Print.prototype": {
@@ -30,11 +30,11 @@ GeoExt.Lang.add("fr", {
     },
     "gxp.plugins.he.GeoStoreStyleWriter.prototype": {
         mainLoadingMask: "S'il vous plaît, attendez...",
-        geostoreStyleErrorTitle: "Erreur",   
+        geostoreStyleErrorTitle: "Erreur",
         geostoreStyleCreationErrorMsg: "Erreur de création du style de GeoStore",
-        geostoreStyleUpdateErrorMsg: "Erreur mise à jour style GeoStore",    
+        geostoreStyleUpdateErrorMsg: "Erreur mise à jour style GeoStore",
         geostoreStyleSearchErrorMsg: "Impossible de récupérer le style de GeoStore",
-        geostoreStyleDeleteSuccessMsg: "Le style GeoStore supprimé avec succès",    
+        geostoreStyleDeleteSuccessMsg: "Le style GeoStore supprimé avec succès",
         geostoreStyleDeleteErrorMsg: "GeoStore style pas supprimé"
     },
 
@@ -64,10 +64,10 @@ GeoExt.Lang.add("fr", {
          stylesFieldsetTitle: "Styles",
          rulesFieldsetTitle: "Des règles",
          errorTitle: "Le style d'économie d'erreur",
-         errorMsg: "Il y avait une économie du style vers le serveur erreur.",         
+         errorMsg: "Il y avait une économie du style vers le serveur erreur.",
          searchStyleResourcesErrorTitle: "Erreur",
          searchStyleResourcesErrorMsg: "Quelque chose a mal tourné lors du chargement de styles"
-    },  
+    },
 
     "gxp.he.WMSLayerPanelHE.prototype": {
         aboutText: "A propos",
@@ -86,5 +86,38 @@ GeoExt.Lang.add("fr", {
         loadMaskMsg: "Extraction des données en cours...",
         noDataMsg: "Pas de données disponibles dans la vue actuelle",
         refreshText: "Actualiser"
+    },
+
+    "gxp.form.MapsComboBox.prototype": {
+        fieldLabel: "Cartes de l'utilisateur",
+        emptyText:"Cartes",
+        valueNotFoundText: "Cartes"
+    },
+
+    "gxp.plugins.he.MapSelector.prototype": {
+        mapActionText: "Carte Actions",
+        mapActionTip: "Carte Actions",
+        saveText: "Conserver",
+        createText: "Créer",
+        deleteText: "Effacer",
+        contextSaveSuccessString: "Contexte de la carte enregistrée avec succès",
+        contextSaveFailString: "Contexte de la carte non enregistré avec succès",
+        contextCreateSuccessString: "Carte créée avec succès",
+        contextCreateFailString: "Carte non créé avec succès",
+        contextDeleteSuccessString: "Carte supprimé avec succès",
+        contextDeleteFailString: "Carte non supprimé avec succès",
+        saveTitle: "Sauvegarder Carte Contexte?",
+        saveMsg: "Aimeriez-vous pour enregistrer vos modifications?",
+        createTitle: "Créer une nouvelle carte?",
+        createMsg: "Aimeriez-vous pour sauver la carte contexte que nouvelle carte?",
+        deleteTitle: "Supprimer la carte?",
+        deleteMsg: "Voulez-vous supprimer votre carte?",
+        addResourceButtonText: "Ajouter Carte",
+        contextMsg: "Chargement...",
+        mapMetadataTitle: "Insérez Carte Métadonnées",
+        mapMedatataSetTitle: "Carte Métadonnées",
+        mapNameLabel: "Prénom",
+        mapDescriptionLabel: "Description",
+        conflictErrMsg: "Une carte avec le même nom existe déjà"
     }
 });

--- a/mapcomposer/app/applications/he/static/hetranslations/it.js
+++ b/mapcomposer/app/applications/he/static/hetranslations/it.js
@@ -20,9 +20,9 @@ GeoExt.Lang.add("it", {
         groupsLabel:"Grouppi",
         gsErrorTitle:"Errore Geostore",
         gsGetPermissionError:"Impossibile recuperare permessi risorsa."
-    },    
+    },
     "gxp.plugins.PrintSnapshotHE.prototype" :{
-        noSupportedLayersErrorMsg: " non è disponibile per la stampa.<br/>Selezionare uno dei seguenti sfondi e riprovare:<br/>",    
+        noSupportedLayersErrorMsg: " non è disponibile per la stampa.<br/>Selezionare uno dei seguenti sfondi e riprovare:<br/>",
         suggestionLayersMsg: "-> OpenStreetMap <br/> -> MapQuest OpenStreetMap <br/> -> MapQuest Imagery"
     },
     "gxp.plugins.Print.prototype": {
@@ -30,11 +30,11 @@ GeoExt.Lang.add("it", {
     },
     "gxp.plugins.he.GeoStoreStyleWriter.prototype": {
         mainLoadingMask: "Attendere prego...",
-        geostoreStyleErrorTitle: "Errore",   
+        geostoreStyleErrorTitle: "Errore",
         geostoreStyleCreationErrorMsg: "Errore nel creare lo stile in geostore.",
-        geostoreStyleUpdateErrorMsg: "Errore nell'aggiornare lo stile in geostore.",    
+        geostoreStyleUpdateErrorMsg: "Errore nell'aggiornare lo stile in geostore.",
         geostoreStyleSearchErrorMsg: "Reicerco dello stile in geostore fallita.",
-        geostoreStyleDeleteSuccessMsg: "Lo stile in geostore è stato eliminato con successo.",    
+        geostoreStyleDeleteSuccessMsg: "Lo stile in geostore è stato eliminato con successo.",
         geostoreStyleDeleteErrorMsg: "Lo stile in geostore non è stato eliminato correttamente."
     },
 
@@ -64,19 +64,52 @@ GeoExt.Lang.add("it", {
          stylesFieldsetTitle: "Stili",
          rulesFieldsetTitle: "Regole",
          errorTitle: "Errore salvataggio stile",
-         errorMsg: "Si è verificato un errore nel salvare lo stile sul server.",                 
+         errorMsg: "Si è verificato un errore nel salvare lo stile sul server.",
          searchStyleResourcesErrorTitle: "Error",
          searchStyleResourcesErrorMsg: "Something went wrong when loading styles"
     },
-    
+
     "gxp.plugins.he.StylerHE.prototype": {
         menuText: "Stili dei layer",
-        tooltip: "Stili dei layer",    
+        tooltip: "Stili dei layer",
         geostoreStyleCategoryCreatedSuccessTitle: "Creazione categoria di GeoStore.",
         geostoreStyleCategoryCreatedSuccessMsg: "La categoria LAYERS_STYLES è stata creata correttamente.",
         geostoreStyleCategoryCreatedErrorTitle: "Errore nella creazione della categoria.",
         geostoreStyleCategoryCreatedErrorMsg: "GeoStore disabilitato, solamente l'Amministratore può creare la categoria mancante LAYERS_STYLES.",
         geostoreStyleCategorySearchErrorTitle: "Errore nella ricerca delle categorie.",
         geostoreStyleCategorySearchErrorMsg: "Qualcosa è andato storto nella ricerca delle categorie."
-    }    
+    },
+
+    "gxp.form.MapsComboBox.prototype": {
+        fieldLabel: "Mappe utente",
+        emptyText:"Lista Mappe",
+        valueNotFoundText: "Lista Mappe"
+    },
+
+    "gxp.plugins.he.MapSelector.prototype": {
+        mapActionText: "Azioni Mappa",
+        mapActionTip: "Azioni Mappa",
+        saveText: "Salva",
+        createText: "Crea",
+        deleteText: "Elimina",
+        contextSaveSuccessString: "Mappa salvata",
+        contextSaveFailString: "Impossibile salvare mappa",
+        contextCreateSuccessString: "Mappa creata",
+        contextCreateFailString: "Impossibile creare mappa",
+        contextDeleteSuccessString: "Mappa eliminata",
+        contextDeleteFailString: "Impossibile eliminare mappa",
+        saveTitle: "Salvare Mappa?",
+        saveMsg: "Vuoi salvare le modifiche?",
+        createTitle: "Creare Nuova Mappa?",
+        createMsg: "Vuoi salvare la mappa corrente come nuova mappa?",
+        deleteTitle: "Eliminare Mappa?",
+        deleteMsg: "Vuoi eliminare la mappa?",
+        addResourceButtonText: "Crea Mappa",
+        contextMsg: 'Loading...',
+        mapMetadataTitle: "Iserire Metadati Mappa",
+        mapMedatataSetTitle: "Metadati Mappa",
+        mapNameLabel: "Nome",
+        mapDescriptionLabel: "Descrizione",
+        conflictErrMsg: "Esiste già una mappa con questo nome"
+    }
 });

--- a/mapcomposer/app/applications/he/static/script/plugins/MapSelector.js
+++ b/mapcomposer/app/applications/he/static/script/plugins/MapSelector.js
@@ -1,0 +1,628 @@
+/**
+ *  Copyright (C) 2007 - 2015 GeoSolutions S.A.S.
+ *  http://www.geo-solutions.it
+ *
+ *  GPLv3 + Classpath exception
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+/**
+ * @author Andrea Cappugi (kappu72@gmail.com)
+ */
+
+/**
+ * @requires widgets/form/MapsComboBox.js
+ */
+
+/** api: (define)
+ *  module = gxp.plugins
+ *  class = MapSelector
+ */
+
+/** api: (extends)
+ *  plugins/Tool.js
+ */
+Ext.namespace("gxp.plugins.he");
+
+/** api: constructor
+ *  .. class:: MapSelector(config)
+ *
+ *    Plugin for select and load user's maps
+ */
+gxp.plugins.he.MapSelector = Ext.extend(gxp.plugins.Tool, {
+
+    /** api: ptype = gxp_mapselector */
+    ptype: "gxp_mapselector",
+
+    /** api: config[mapActionText]
+     *  ``String``
+     */
+    mapActionText: "Map Actions",
+
+    /** api: config[saveDefaultContextActionTip]
+     *  ``String``
+     */
+    mapActionTip: "Map actions",
+
+
+    /** api: config[saveText]
+     *  ``String``
+     */
+    saveText: "Save",
+
+    /** api: config[createText]
+     *  ``String``
+     */
+    createText: "Create",
+
+    /** api: config[deleteText]
+     *  ``String``
+     */
+    deleteText: "Delete",
+
+    /** api: config[contextSaveSuccessString]
+     *  ``String``
+     */
+    contextSaveSuccessString: "Map context saved succesfully",
+
+    /** api: config[contextSaveFailString]
+     *  ``String``
+     */
+    contextSaveFailString: "Map context not saved succesfully",
+
+    /** api: config[contextCreateSuccessString]
+     *  ``String``
+     */
+    contextCreateSuccessString: "Map created succesfully",
+
+    /** api: config[contextCreateFailString]
+     *  ``String``
+     */
+    contextCreateFailString: "Map not created succesfully",
+
+    /** api: config[contextCreateSuccessString]
+     *  ``String``
+     */
+    contextDeleteSuccessString: "Map deleted succesfully",
+
+    /** api: config[contextDeleteSuccessString]
+     *  ``String``
+     */
+    contextDeleteFailString: "Map not deleted succesfully",
+
+    /** api: config[saveTitle]
+     *  ``String``
+     */
+    saveTitle: "Save Map Context?",
+
+    /** api: config[saveMsg]
+     *  ``String``
+     */
+    saveMsg: "Would you like to save your changes?",
+
+    /** api: config[createTitle]
+     *  ``String``
+     */
+    createTitle: "Create New Map?",
+
+    /** api: config[createMsg]
+     *  ``String``
+     */
+    createMsg: "Would you like to save map context as new map?",
+
+    /** api: config[deleteTitle]
+     *  ``String``
+     */
+    deleteTitle: "Delete Map?",
+
+    /** api: config[deleteMsg]
+     *  ``String``
+     */
+    deleteMsg: "Would you like delete your map?",
+
+    /** api: config[addResourceButtonText]
+     *  ``String``
+     */
+    addResourceButtonText: "Add Map",
+
+    /** api: config[auth]
+     *  ``String``
+     */
+    auth: null,
+
+    /**
+    * Property: contextMsg
+    * {string} string to add in loading message
+    *
+    */
+    contextMsg: 'Loading...',
+
+    /**
+    * Property: mapMetadataTitle
+    * {string}
+    *
+    */
+    mapMetadataTitle: "Insert Map Metadata",
+
+    /**
+    * Property: mapMedatataSetTitle
+    * {string}
+    *
+    */
+    mapMedatataSetTitle: "Map Metadata",
+
+    /**
+    * Property: mapNameLabel
+    * {string}
+    *
+    */
+    mapNameLabel: "Name",
+
+    /**
+    * Property: mapDescriptionLabel
+    * {string}
+    *
+    */
+    mapDescriptionLabel: "Description",
+
+    /**
+     * Property: conflictErrMsg
+     * {string}
+     */
+    conflictErrMsg: "A map with the same name already exists",
+
+     /** api: method[addActions]
+     */
+    addActions: function() {
+        this.target.on("ready", function() {
+            this.roleAdmin=(this.target && this.target.userDetails && this.target.userDetails.user.role == "ADMIN");
+            this.advancedUser=this.hasGroup(this.target.userDetails.user,'Advanced_Users');
+            this.user = this.target.userDetails.user.name;
+            this.defaultMap = this.getDefaultMap();
+            this.addOutput();
+        },this);
+
+        return
+    },
+
+     /** private: method[addOutput]
+     *  :arg config: ``Object``
+     */
+    addOutput: function() {
+
+        var user, password;
+        if(this.target.authToken) {
+            var parts = Base64.decode(this.target.authToken.substring(6)).split(':');
+            user = parts[0];
+            password = parts[1];
+        }
+        var mask =this.target.appMask;
+        this.geoStore = new gxp.plugins.GeoStoreClient({
+            url: this.target.geoStoreBaseURL,
+            user: user || undefined,
+            password: password || undefined,
+            authToken: this.target.authToken || undefined,
+            proxy: this.target.proxy
+        });
+        this.saveBtn = new Ext.menu.CheckItem({
+            text: this.saveText,
+            iconCls: "gxp-icon-savedefaultcontext",
+            allowDepress:false,
+            disabled:true,
+            ref:"../saveBtn",
+            handler: function() {
+                    Ext.Msg.show({
+                    title:this.saveTitle,
+                    msg: this.saveMsg,
+                    buttons: Ext.Msg.YESNO,
+                    fn: function(btnId){
+                        if(btnId==='yes'){
+                            var configStr = Ext.util.JSON.encode(this.target.getState());
+                            mask.show();
+                            var restPath="/data/"+this.target.mapId;
+                            this.geoStore.sendRequest(restPath, "PUT", configStr, 'application/json', this.updateSuccess, this.updateFail,this);
+                        }
+                    },
+                    scope:this,
+                    icon: Ext.MessageBox.QUESTION
+                    });
+            },
+            scope: this
+        });
+        this.createBtn = new Ext.menu.CheckItem({
+            text: this.createText,
+            iconCls: "map_add",
+            toggleGroup: this.toggleGroup,
+            allowDepress:false,
+            disabled:false,
+            handler:function() {
+                Ext.Msg.show({
+                    title: this.createTitle,
+                    msg: this.createMsg,
+                    buttons: Ext.Msg.YESNO,
+                    fn: function(btnId){
+                        if(btnId==='yes'){
+                            var configStr = Ext.util.JSON.encode(this.target.getState());
+                            this.metadataDialog(configStr);
+                        }
+                    },
+                    scope:this,
+                    icon: Ext.MessageBox.QUESTION
+                    });
+                },
+            scope: this
+        });
+        this.deleteBtn = new Ext.menu.CheckItem({
+            text: this.deleteText,
+            iconCls: "map_delete",
+            allowDepress:false,
+            disabled:true,
+            handler: function(){
+                Ext.Msg.show({
+                    title: this.deleteTitle,
+                    msg: this.deleteMsg,
+                    buttons: Ext.Msg.YESNO,
+                    fn: function(btnId){
+                        if(btnId==='yes'){
+                            this.geoStore.deleteEntity(new OpenLayers.GeoStore.Resource({id:this.target.mapId}), this.deleteSuccess, this.deleteFail, this);
+                        }
+                    },
+                    scope:this,
+                    icon: Ext.MessageBox.QUESTION
+                    });
+
+                 },
+                scope: this
+    });
+
+        var menuBtn = new Ext.SplitButton({
+            text: this.mapActionText,
+            hidden: !(this.roleAdmin || this.advancedUser),
+            tooltip: this.mapActionTip,
+            allowDepress: true,
+            scope: this,
+            menu: new Ext.menu.Menu({
+                items: [ this.createBtn,this.saveBtn,this.deleteBtn]
+            })
+        });
+        var user = this.user;
+        var config = {
+            xtype:'buttongroup',
+            items: [{
+                xtype:"gxp_mapscombobox",
+                geoStoreBase: this.target.geoStoreBaseURL,
+                defaultSelection: this.target.mapId || null,
+                fields: [
+                    {name:'id', mapping:'id'},
+                    {name:'name', mapping:'name'},
+                    {name:'owner', mapping:'owner'},
+                    {name:'group', mapping:function(data){ return data.owner != user ? 'Public':'Personal';}}
+                ],
+                sort: {
+                    field: 'group',
+                    direction: 'ASC' // or 'DESC' (case sensitive for local sorting)
+                },
+                tpl: new Ext.XTemplate(
+                    '<tpl for=".">',
+                    '<tpl if="this.group != values.group">',
+                    '<tpl exec="this.group = values.group; console.log(this,values)"></tpl>',
+                    ' <h1><span style="color:gray">{group}</span></h1>',
+                    '</tpl>',
+                    '<div class="x-combo-list-item">{name}</div>',
+                    '</tpl>'
+                ),
+                listeners: {
+                    select: function(combo, record, index){
+                        var nMapId=record.get('id');
+                        if(this.target.mapId !== nMapId){
+                              this.reloadMap(nMapId,this.target.mapId);
+                        }
+                    },
+                    defaultLoaded: function(record){
+                            if(record.get("id") === this.target.mapId){
+                                (record.json.canEdit) ? this.saveBtn.enable():this.saveBtn.disable();
+                                (record.json.canDelete) ? this.deleteBtn.enable():this.deleteBtn.disable();
+                                (record.json.canCopy) ? this.createBtn.enable():this.createBtn.disable();
+                            }
+
+                    },
+                scope:this
+                }
+            }, menuBtn]};
+
+        //We have to insert the tool at passed index
+        var idx = this.idx || null;
+        var parts = this.outputTarget.split(".");
+        var ref = parts[0];
+        var item = parts.length > 1 && parts[1];
+        var container = ref ? ref == "map" ?
+                        this.target.mapPanel : (Ext.getCmp(ref) || this.target.portal[ref]) :
+                            this.target.portal;
+            if (item) {
+                var meth = {
+                        "tbar": "getTopToolbar",
+                        "bbar": "getBottomToolbar",
+                        "fbar": "getFooterToolbar"
+                    }[item];
+                    if (meth) {
+                        container = container[meth]();
+                    } else {
+                        container = container[item];
+                    }
+                }
+            Ext.apply(config, this.outputConfig);
+            var component = (idx === null) ? container.add(config) : container.insert(idx, config);
+            container.doLayout();
+            this.output.push(component);
+            return component;
+
+    },
+     /** private: method[hasGroup]
+     *  ``Function`` Check if users has passed group
+     *
+     */
+    hasGroup: function(user, targetGroups){
+                if(user && user.groups && targetGroups){
+                    var groupfound = false;
+                    for (var key in user.groups.group) {
+                        if (user.groups.group.hasOwnProperty(key)) {
+                            var g = user.groups.group[key];
+                            if(g.groupName && targetGroups.indexOf(g.groupName) > -1 ){
+                                groupfound = true;
+                            }
+                        }
+                    }
+                    return groupfound;
+                }
+
+                return false;
+            },
+    /** private: method[reloadMap]
+     *  ``Function`` Load map
+     *     :arg mapId: ``Int``
+     *     :arg oldId: ``Int``
+     */
+    reloadMap: function(mapId,oldId){
+            this.target.appMask.show();
+
+            if(window.location.search.search('mapId='+oldId)!=-1){
+                    var url = window.location.href.replace('mapId='+oldId,(mapId)?'mapId='+mapId:'');
+                    url = (url.indexOf('?') === url.length -1 ) ? url.substr(0,url.length -1) :url;
+                    window.location.replace(url);
+            }else{
+                            var newUrl = window.location.href;
+                            newUrl += (window.location.search.length>0)? "&mapId="+ mapId : "?mapId="+mapId;
+                            window.location.replace(newUrl);
+                        }
+    },
+    updateSuccess: function (response){
+              this.target.appMask.hide();
+              this.target.modified = false;
+              this.target.mapId = parseInt(response.responseText);
+              Ext.Msg.show({
+                   title: this.contextSaveSuccessString,
+                   msg: response.statusText + " " + this.contextSaveSuccessString,
+                   buttons: Ext.Msg.OK,
+                   icon: Ext.MessageBox.OK
+              });
+    },
+    updateFail: function(response){
+              Ext.Msg.show({
+                   title: this.contextSaveFailString,
+                   msg: this.getSaveFailedErrMsg(response) + " " + this.contextSaveFailString,
+                   buttons: Ext.Msg.OK,
+                   icon: Ext.MessageBox.OK
+              });
+    },
+    createSuccess: function (response){
+              this.target.appMask.hide();
+              this.target.modified = false;
+
+              var oldId = this.target.mapId;
+              var newId = parseInt(response.responseText);
+              this.target.mapId = newId;
+
+              var reload = function(buttonId, text, opt){
+                    this.reloadMap(newId,oldId);
+              };
+
+              Ext.Msg.show({
+                   title: this.contextCreateSuccessString,
+                   msg: response.statusText + " " + this.contextCreateSuccessString,
+                   buttons: Ext.Msg.OK,
+                   fn: reload,
+                   icon: Ext.MessageBox.OK,
+                   scope: this
+              });
+    },
+    createFail: function(response){
+              Ext.Msg.show({
+                   title: this.contextCreateFailString,
+                   msg: this.getSaveFailedErrMsg(response) + " " + this.contextCreateFailString,
+                   buttons: Ext.Msg.OK,
+                   icon: Ext.MessageBox.OK
+              });
+    },
+    deleteSuccess: function(response){
+            var oldId = this.target.mapId;
+            var newId = (this.defaultMap);
+            var reload = function(buttonId, text, opt){
+                    this.reloadMap(newId,oldId);
+              };
+              this.target.mapId=-1;
+              Ext.Msg.show({
+                   title: this.contextDeleteSuccessString,
+                   msg: response.statusText + " " + this.contextDeleteSuccessString,
+                   buttons: Ext.Msg.OK,
+                   fn: reload,
+                   icon: Ext.MessageBox.OK,
+                   scope: this
+              });
+    },
+    deleteFail: function(response){
+              Ext.Msg.show({
+                   title: this.contextDeleteFailString,
+                   msg: this.getSaveFailedErrMsg(response) + " " + this.contextDeleteFailString,
+                   buttons: Ext.Msg.OK,
+                   icon: Ext.MessageBox.OK
+              });
+    },
+
+    getSaveFailedErrMsg: function(response) {
+        var errMsg = null;
+        var defaultErrMsg = response.statusText + "(status " + response.status + "):  " + response.responseText;
+
+        switch (response.status) {
+            case 409:
+                errMsg = this.conflictErrMsg;
+                break;
+            default:
+                errMsg = defaultErrMsg;
+                break;
+        }
+
+        return errMsg;
+    },
+
+    metadataDialog: function(configStr){
+        var enableBtnFunction = function(){
+            if(this.getValue() != "")
+                Ext.getCmp("resource-addbutton").enable();
+            else
+                Ext.getCmp("resource-addbutton").disable();
+        };
+
+        var templateId = this.target.templateId;
+        var plugin = this;
+        var win = new Ext.Window({
+            title: this.mapMetadataTitle,
+            width: 415,
+            height: 200,
+            resizable: false,
+            //title: "Map Name",
+            items: [
+                new Ext.form.FormPanel({
+                    width: 400,
+                    height: 150,
+                    items: [
+                        {
+                          xtype: 'fieldset',
+                          id: 'name-field-set',
+                          title: this.mapMedatataSetTitle,
+                          items: [
+                              {
+                                    xtype: 'textfield',
+                                    width: 120,
+                                    id: 'diag-text-field',
+                                    fieldLabel: this.mapNameLabel,
+                                    listeners: {
+                                        render: function(f){
+                                            f.el.on('keydown', enableBtnFunction, f, {buffer: 350});
+                                        }
+                                    }
+                              },
+                              {
+                                    xtype: 'textarea',
+                                    width: 200,
+                                    id: 'diag-text-description',
+                                    fieldLabel: this.mapDescriptionLabel,
+                                    readOnly: false,
+                                    hideLabel : false
+                              }
+                          ]
+                        }
+                    ]
+                })
+            ],
+            bbar: new Ext.Toolbar({
+                items:[
+                    '->',
+                    {
+                        text: this.addResourceButtonText,
+                        iconCls: "gxp-icon-addgroup-button",
+                        id: "resource-addbutton",
+                        scope: this,
+                        disabled: true,
+                        handler: function(){
+                            win.hide();
+
+                            var mapName = Ext.getCmp("diag-text-field").getValue();
+                            var mapDescription = Ext.getCmp("diag-text-description").getValue();
+                            var auth = plugin.getAuth();
+                            var owner = Base64.decode(auth.split(' ')[1]);
+                            owner = owner.split(':')[0];
+
+                            var resourceXML =
+                                '<Resource>' +
+                                    '<Attributes>' +
+                                        '<attribute>' +
+                                            '<name>owner</name>' +
+                                            '<type>STRING</type>' +
+                                            '<value>' + owner + '</value>' +
+                                        '</attribute>' +
+                                        '<attribute>' +
+                                            '<name>templateId</name>' +
+                                            '<type>STRING</type>' +
+                                            '<value>' + templateId + '</value>' +
+                                        '</attribute>' +
+                                    '</Attributes>' +
+                                    '<description>' + mapDescription + '</description>' +
+                                    '<metadata></metadata>' +
+                                    '<name>' + mapName + '</name>' +
+                                    '<category>' +
+                                        '<name>MAP</name>' +
+                                    '</category>' +
+                                    '<store>' +
+                                        '<data><![CDATA[ ' + configStr + ' ]]></data>' +
+                                    '</store>' +
+                                '</Resource>';
+                            this.geoStore.sendRequest("/resources", "POST",resourceXML, "text/xml", this.createSuccess, this.createFail, this);
+                            win.destroy();
+                        }
+                    }
+                ]
+            })
+        });
+        win.show();
+    },
+    getDefaultMap: function(){
+        var userDetails = Ext.util.JSON.decode(sessionStorage["userDetails"]);
+        var defaultMap=null;
+        var attributes=[];
+        // get auth info
+        if (userDetails) {
+            var user = userDetails.user;
+            if(user){
+                //Check if user as default_map attribute defined
+                if(user.attribute) {
+                    if(user.attribute instanceof Array)
+                        attributes=user.attribute;
+                    else
+                        attributes.push(user.attribute);
+                    for(var i = 0; i<attributes.length;i++) {
+                            if(attributes[i].name=='default_map'){
+                                defaultMap=attributes[i].value;
+                                break;
+                            }
+                    }
+                }
+            }
+        }
+        return defaultMap;
+    }
+});
+
+Ext.preg(gxp.plugins.he.MapSelector.prototype.ptype, gxp.plugins.he.MapSelector);
+
+//# sourceURL=MapSelector.js

--- a/mapcomposer/app/applications/he/static/script/widgets/form/MapsComboBox.js
+++ b/mapcomposer/app/applications/he/static/script/widgets/form/MapsComboBox.js
@@ -1,0 +1,148 @@
+/*
+ *  Copyright (C) 2007 - 2014 GeoSolutions S.A.S.
+ *  http://www.geo-solutions.it
+ *
+ *  GPLv3 + Classpath exception
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+/**
+ * @author Andrea Cappugi (kappu72@gmail.com)
+ */
+
+/** api: (define)
+ *  module = gxp.form
+ *  class = MapsComboBox
+ *
+ */
+Ext.ns('gxp.form');
+
+/**
+ * Class: MapsComboBox
+ * User maps simple combobox
+ *
+ * Inherits from:
+ *  - <Ext.form.ComboBox>
+ *
+ */
+gxp.form.MapsComboBox = Ext.extend(Ext.form.ComboBox, {
+
+ 	/** xtype = gxp_mapscombobox **/
+    xtype: "gxp_mapscombobox",
+
+    // i18n
+    fieldLabel: "User maps",
+    emptyText:"Maps",
+    valueNotFoundText: "Maps",
+
+    // base config
+    width: 120,
+    typeAhead: true,
+    triggerAction: 'all',
+    lazyRender:true,
+    valueField: 'id',
+    displayField: 'name',
+
+    // specifig config
+    url: null,
+    auth: null,
+
+    // select  by default by name
+    defaultSelection: null,
+    editable: false,
+    allowBlank: false,
+    geoStoreBase:null,
+
+    initComponent: function(){
+        this.addEvents('defaultLoaded');
+        var role,groups;
+        if(sessionStorage && sessionStorage["userDetails"]){
+            var userDetails = sessionStorage["userDetails"];
+            userDetails = Ext.decode(userDetails);
+            var role = userDetails.user.role;
+            var groups = userDetails.user.groups.group;
+            var auth = userDetails.token;
+        }
+         if(typeof(manager) !== 'undefined') {
+            this.geoStoreBase = manager.geoStoreBase;
+            this.manager = true;
+         }
+
+        	// storeload
+        	this.store = {
+			xtype: "jsonstore",
+			idProperty: 'id',
+	        root: 'results',
+	        autoLoad: true,
+	        fields: this.fields || [
+	            {name:'id', mapping:'id'},
+	            {name:'name', mapping:'name'},
+                {name:'owner', mapping:'owner'}
+	        ],
+            sortInfo: this.sort || {
+                field: 'owner',
+                direction: 'ASC' // or 'DESC' (case sensitive for local sorting)
+            },
+	        listeners:{
+	        	load: function(store){
+	        		this.fireEvent("storeload", store, this);
+	        		this.loadDefault(store);
+	        	},
+	        	scope: this
+	        },
+	        proxy: new Ext.data.HttpProxy({
+                    url: this.geoStoreBase + 'extjs/search/category/MAP/?includeAttributes=true',
+                    restful: true,
+                    method : 'GET',
+                    disableCaching: false,
+                    headers:{
+                        'Accept': 'application/json',
+                        'Authorization' : auth
+                    },
+                    failure: function (response) {
+                        Ext.Msg.show({
+                           title: "Error Loadin Users Maps",
+                           msg: response.statusText + "(status " + response.status + "):  " + response.responseText,
+                           buttons: Ext.Msg.OK,
+                           icon: Ext.MessageBox.ERROR
+                        });
+                    }
+                })
+		 };
+        gxp.form.MapsComboBox.superclass.initComponent.call(this, arguments);
+	},
+
+	/**
+	 * private:[loadDefault]
+	 *
+	 * Select `this.defaultSelection` if it's configurated
+	 **/
+	loadDefault: function(store){
+		if(this.manager && !this.defaultSelection){
+			this.defaultSelection=this.value;
+		}
+		if(this.defaultSelection){
+			store.each(function(record){
+				if(this.defaultSelection == record.get( "id")){
+					this.setValue(record.get("id"));
+                    this.fireEvent("defaultLoaded", record);
+				}
+			}, this);
+		}
+	}
+});
+
+/** api: xtype = gxp_mapscombobox */
+Ext.reg(gxp.form.MapsComboBox.prototype.xtype, gxp.form.MapsComboBox);
+//# sourceURL=MapsComboBox.js

--- a/mapcomposer/app/applications/he/templates/login.html
+++ b/mapcomposer/app/applications/he/templates/login.html
@@ -4,71 +4,71 @@
     <link rel="stylesheet" type="text/css" href="externals/openlayers/theme/default/style.css">
 
 	<!-- Basic OpenLayers libs -->
-    <script type="text/javascript" src="script/OpenLayers.js"></script>		
-	
+    <script type="text/javascript" src="script/OpenLayers.js"></script>
+
 	<!-- Externatls OpenLayers libraries to manage other extensions -->
-	<script type="text/javascript" src="script/OpenLayersExt.js"></script> 
-    
+	<script type="text/javascript" src="script/OpenLayersExt.js"></script>
+
     <!-- Ask RingoJS for debug status -->
-    <script type="text/javascript" src="debug.js"></script> 
-	
+    <script type="text/javascript" src="debug.js"></script>
+
 	<link rel="stylesheet" type="text/css" href="theme/app/openlayers.css" />
-	
-	<!-- colorpicker resources 
+
+	<!-- colorpicker resources
     <link rel="stylesheet" type="text/css" href="externals/colorpicker/css/colorpicker.css">
     <script type="text/javascript" src="script/colorpicker.js"></script> -->
-	
+
     <!-- GeoExt resources -->
     <link rel="stylesheet" type="text/css" href="externals/GeoExt/resources/css/popup.css">
     <link rel="stylesheet" type="text/css" href="externals/GeoExt/resources/css/layerlegend.css">
-    <link rel="stylesheet" type="text/css" href="externals/GeoExt/resources/css/gxtheme-gray.css">	
-    <script type="text/javascript" src="script/GeoExt.js"></script> 	
-	
+    <link rel="stylesheet" type="text/css" href="externals/GeoExt/resources/css/gxtheme-gray.css">
+    <script type="text/javascript" src="script/GeoExt.js"></script>
+
 	<script type="text/javascript" src="script/GeoExtExt.js"></script>
-	
+
 	<!-- PrintPreview resources  -->
     <link rel="stylesheet" type="text/css" href="externals/PrintPreview/resources/css/printpreview.css">
     <script type="text/javascript" src="script/PrintPreview.js"></script>
-	
+
     <!-- canvg-1.2 resources -->
-	<script type="text/javascript" src="script/canvg-1.2.js"></script> 
+	<script type="text/javascript" src="script/canvg-1.2.js"></script>
 	 <script type="text/javascript" src="script/ux.js"></script>
-   
+
     <!-- gxp resources -->
     <link rel="stylesheet" type="text/css" href="externals/gxp/src/theme/all.css">
-    <script type="text/javascript" src="script/gxp.js"></script> 
+    <script type="text/javascript" src="script/gxp.js"></script>
 
     <script type="text/javascript" src="script/proj4js.js"></script>
 	<script type="text/javascript" src="script/projCodes.js"></script>
 
-   
-    
+
+
     <!-- GeoExplorer resources -->
     <link rel="stylesheet" type="text/css" href="theme/app/geoexplorer.css" />
     <link rel="stylesheet" type="text/css" href="theme/app/mapstore.css" />
-   
+
 	 <link rel="stylesheet" type="text/css" href="css/gcd.css">
     <script type="text/javascript" src="script/gcd.js"></script>
 	<!-- Advanced Scalebar CSS -->
 	<!--link rel="stylesheet" type="text/css" href="theme/app/scalebar-fat.css" /-->
     <link rel="stylesheet" type="text/css" href="theme/app/scalebar-thin.css" />
-	
-    <!--[if IE]><link rel="stylesheet" type="text/css" href="theme/app/ie.css"/><![endif]-->        
+
+    <!--[if IE]><link rel="stylesheet" type="text/css" href="theme/app/ie.css"/><![endif]-->
 
     <script type="text/javascript" src="script/GeoExplorer.js"></script>
-   
+
     <!-- csw resources -->
     <link rel="stylesheet" type="text/css" href="externals/csw/css/csw.css">
     <script type="text/javascript" src="auth/base64.js"></script>
     <script type="text/javascript" src="script/metadataexplorer.js"></script>
-    
+
     <!-- geocoding data  -->
     <script type="text/javascript" src="data/georeferences.js"></script>
      <!-- QR Code -->
     <script type="text/javascript" src="script/qrcodejs.js"></script>
     <!-- common data  -->
     <script type="text/javascript" src="config/common/localConfig.js"></script>
-    
+
 	<!-- translation data  -->
     <script type="text/javascript" src="translations/en.js"></script>
     <script type="text/javascript" src="translations/fr.js"></script>
@@ -82,42 +82,41 @@
     <script type="text/javascript" src="hetranslations/it.js"></script>
     <script type="text/javascript" src="hetranslations/de.js"></script>
     <script type="text/javascript" src="hetranslations/es.js"></script>
-	
+
 	<!-- uncomment to have  welcome screen
 	<script type="text/javascript">
-	 
+
         Ext.onReady(function() {
           setTimeout(function(){
             Ext.get('loading').remove();
             Ext.get('loading-mask').fadeOut({remove:true,duration:1});
           }, 2000);
         });
-   
+
     </script>
-    
+
     <div id="loading-mask"></div>
     <div id="loading">
       <div class="loading-indicator">
       </div>
     </div>
 	-->
-	
+
     <script>
-		var app;        
+		var app;
         var modified = false; var mapIdentifier = -1; var authorization = false; var fullScreen = false; var bbox; var useCookies; var templateId;
-		
 		// /////////////////////////////////////////////////////
 		// Extra parameters to add layers at startup
 		// /////////////////////////////////////////////////////
 		var layName; var layTitle; var wmsurl; var gsturl;
-		
+
         // ///////////////////////////////////////////////////////////////
-        // Custom variables from the mapStoreConfig user configuration file 
+        // Custom variables from the mapStoreConfig user configuration file
         // ///////////////////////////////////////////////////////////////
-        var proxy; 
+        var proxy;
         var serverConfig;
-        var customConfigName;		
-		
+        var customConfigName;
+
         // //////////////////////////////////////////////////
         // Parsing the request to get the parameters
         // //////////////////////////////////////////////////
@@ -126,89 +125,89 @@
 			var param = params[j].split("=");
 			if(param[0]){
 				switch ( param[0] ) {
-					case "mapId": 
+					case "mapId":
 									try{
 										mapIdentifier = parseInt(param[1]);
 									}catch(e){
 										mapIdentifier = -1;
-									} 
+									}
 									break;
-					case "auth" : 
-									if(param[1] == 'true') 
-										authorization = true; 
-									else 
-										authorization = false; 
+					case "auth" :
+									if(param[1] == 'true')
+										authorization = true;
+									else
+										authorization = false;
 									break;
-					case "fullScreen" : 
-									if(param[1] == 'true') 
-										fullScreen = true; 
-									else 
-										fullScreen = false; 
+					case "fullScreen" :
+									if(param[1] == 'true')
+										fullScreen = true;
+									else
+										fullScreen = false;
 									break;
-					case "layName" : 
-									layName = param[1]; 
+					case "layName" :
+									layName = param[1];
 									break;
-					case "layTitle" : 
-									layTitle = param[1]; 
+					case "layTitle" :
+									layTitle = param[1];
 									break;
-					case "wmsurl" : 
-									wmsurl = param[1]; 
+					case "wmsurl" :
+									wmsurl = param[1];
 									wmsurl = decodeURIComponent(wmsurl);
 									break;
-					case "gsturl" : 
-									gsturl = param[1]; 
+					case "gsturl" :
+									gsturl = param[1];
 									gsturl = decodeURIComponent(gsturl);
 									break;
-					case "useCookies" : 
-									useCookies = param[1]; 
+					case "useCookies" :
+									useCookies = param[1];
 									break;
-					case "config":	
+					case "config":
 									customConfigName = param[1];
 									break;
-					case "bbox": 
+					case "bbox":
 									try{
 										bbox = new OpenLayers.Bounds.fromString(param[1]);
 									}catch(e){
 										bbox = undefined;
-									} 
+									}
 									break;
-					case "configId": 
+					case "configId":
 									try{
 										templateId = parseInt(param[1]);
 									}catch(e){
 										templateId = -1;
-									} 
+									}
 									break;
-					default :       
+					default :
 									//mapIdentifier = -1;
 									//authorization = false;
-									//fullScreen = false; 
+									//fullScreen = false;
 				}
 			}
-        }		
-		
+        }
+
         var onReady = function(){
 
-            
+
 
             OpenLayers.ImgPath = "externals/openlayers/theme/default/img/";
-			
+
 			// ////////////////////////////////
-            // Get Proj4js configuration 
+            // Get Proj4js configuration
 			// ////////////////////////////////
             if( typeof(Proj4js)!="undefined" && !(serverConfig.proj4jsDefs===undefined) ){
                 for(var name in serverConfig.proj4jsDefs){
-                    Proj4js.defs[name] = serverConfig.proj4jsDefs[name];               
+                    Proj4js.defs[name] = serverConfig.proj4jsDefs[name];
                 }
             }
-            
+
 			// /////////////////////////////////////
             // Get georeferences data to override
 			// /////////////////////////////////////
             if (serverConfig.georeferences_data){
                 georeferences_data = serverConfig.georeferences_data;
             }
-			
+
             gxp.plugins.ZoomToExtent.prototype.closest = false;
 
             Ext.ux.IFrameComponent = Ext.extend(Ext.BoxComponent, {
@@ -216,18 +215,18 @@
                       this.el = ct.createChild({
                         tag: 'iframe',
                         id: 'iframe-'+ this.id,
-                        frameBorder: 0, 
+                        frameBorder: 0,
                         src: this.url
                       });
                  }
             });
 
-            // User Utility Method 
+            // User Utility Method
             // Scan the user groups to find a match with the given one
             // Returns false if user has no groups or if the group is not found
-            
+
             var hasGroup = function(user, targetGroups){
-            
+
                 if(user && user.groups && targetGroups){
                     var groupfound = false;
                     for (var key in user.groups.group) {
@@ -240,20 +239,20 @@
                     }
                     return groupfound;
                 }
-                
+
                 return false;
             }
-			
-		    // //////////////////////////////////////////////////////            
+
+		    // //////////////////////////////////////////////////////
             // Setting the locale based on query string parameter
             // //////////////////////////////////////////////////////
-			var query = location.search;        
+			var query = location.search;
             if(query && query.substr(0,1) === "?"){
                 query = query.substring(1);
             }
-            
-            var url = Ext.urlDecode(query);        
-            var code = url.locale || serverConfig.defaultLanguage || "en";			
+
+            var url = Ext.urlDecode(query);
+            var code = url.locale || serverConfig.defaultLanguage || "en";
 
 			// ////////////////////////////////////////////////////
 			// Setting the language code for the GeoExt tools
@@ -261,44 +260,44 @@
 			if (GeoExt.Lang) {
                 GeoExt.Lang.set(code);
             }
-			
+
             var appTabsOpts = {
 				region: 'center',
 				border : false,
 				id : 'appTabs',
 				enableTabScroll: true
             };
-            
+
             //check if MetadataExplorer plugin is defined in customTools configuration
             var customToolsME = [];
             if(serverConfig.customTools){
                 for(var cTools in serverConfig.customTools){
-                    if(serverConfig.customTools[cTools].ptype == "gxp_metadataexplorer"){  
+                    if(serverConfig.customTools[cTools].ptype == "gxp_metadataexplorer"){
                         customToolsME.push(serverConfig.customTools[cTools].ptype);
                     }
                 }
             }
-            
+
             //check if MetadataExplorer plugin is defined in tools configuration
-            var toolsME = [];                
+            var toolsME = [];
             if(serverConfig.tools){
                 for(var tools in serverConfig.tools){
-                    if(serverConfig.tools[tools].ptype == "gxp_metadataexplorer"){  
+                    if(serverConfig.tools[tools].ptype == "gxp_metadataexplorer"){
                         toolsME.push(serverConfig.tools[tools].ptype);
                     }
                 }
-            }            
-            
+            }
+
             if(!serverConfig.tab && toolsME.length == 0 && customToolsME.length == 0){
                 appTabsOpts.layout = 'fit';
-                appTabs = new Ext.Panel(appTabsOpts); 
+                appTabs = new Ext.Panel(appTabsOpts);
             }else{
-                appTabs = new Ext.TabPanel(appTabsOpts); 
+                appTabs = new Ext.TabPanel(appTabsOpts);
             }
-			
+
 			var header = serverConfig.header;
 			var footer = serverConfig.footer;
-			
+
 			var viewport = {
 					id: 'appVieport',
 					layout: 'fit',
@@ -310,43 +309,43 @@
 				for(var key in knownInteger){
 					if(section[key]){
 						try{
-							section[key] = parseInt(section[key]);	
+							section[key] = parseInt(section[key]);
 						}catch (e){
 							// unknown parameter value
 						}
-					}	
+					}
 				}
 				return section;
 			}
-			
+
 			if(header || footer){
 				var north = {
 					header: false,
 					region: 'north',
 					id: 'msheader'
 				};
-			
+
 				if(header){
 					north = Ext.applyIf(north, (header.container ? parseKnowIntegers(header.container) : {}));
 					north.html = (header.css || '') + (header.html || '');
 				}
-				
+
 			    var south = {
 					header: false,
 					region: 'south',
 					id: 'msfooter'
 				};
-				
+
 				if(footer){
 					south = Ext.applyIf(south, (footer.container ? parseKnowIntegers(footer.container) : {}));
 					south.html = (footer.css || '') + (footer.html || '');
 				}
-				
+
 				viewport.items = [{
 					region: 'center',
 					layout: 'border',
 					border: false,
-					header: false, 
+					header: false,
 					items: [north, appTabs, south]
 				}];
 			}else{
@@ -354,20 +353,20 @@
 					region: 'center',
 					layout: 'border',
 					border: false,
-					header: false,                    
+					header: false,
 					items: [appTabs]
 				}]
-			}			
-			
+			}
+
 			var appViewport = new Ext.Viewport(viewport);
-            
+
             var footer=Ext.getDom('footer');
             var thisDate=new Date();
             var thisYear=thisDate.getFullYear();
             if(footer) {
                 footer.innerHTML+=thisYear+"&nbsp;";
             }
-            
+
             // /////////////////////////////////////////////////////////////
             // Parsing WMS servers Sources for getCapabilities operation
             // /////////////////////////////////////////////////////////////
@@ -391,7 +390,7 @@
                         ptype: "gxp_olsource"
                     }
                 };
-          
+
                 Ext.Msg.show({
                       title: "Startup",
                       msg: "An error occurred while parsing the CUSTOM GeoServer sources",
@@ -403,11 +402,11 @@
 			if(gsturl){
 				serverConfig.geoStoreBase = gsturl;
 			}
-			
+
 			var initComposer = function(){
                 app = new GeoExplorer.Composer({
                     advancedScaleOverlay: serverConfig.advancedScaleOverlay || false,
-                    defaultLanguage: serverConfig.defaultLanguage,	
+                    defaultLanguage: serverConfig.defaultLanguage,
                     actionToolScale: serverConfig.actionToolScale || "small",
                     customPanels: serverConfig.customPanels,
                     modified: false,
@@ -430,32 +429,32 @@
                     map: serverConfig.map,
                     customTools: serverConfig.customTools,
                     apikeys: serverConfig.apikeys
-                }, mapIdentifier, authorization, fullScreen, templateId);   
-                
+                }, mapIdentifier, authorization, fullScreen, templateId);
+
                 app.on({
                     'portalready' : function() {
-                        
+
                         if(fullScreen) {
                             var westPanel = Ext.getCmp('west');
                             westPanel.setActiveTab('legend');
                             westPanel.hideTabStripItem('tree');
                         }
-                    }, 
+                    },
                     'ready' : function(){
                         app.modified = false;
-                        
+
                         // ///////////////////////////////////////////////////
-                        // Visualizing metadata tab and layers at startup 
+                        // Visualizing metadata tab and layers at startup
                         // ///////////////////////////////////////////////////
                         if(layName && wmsurl || useCookies){
                             var addLayer = app.tools["addlayer"];
-                            
+
                             if(addLayer){
                                 if(useCookies){
                                     var opener = window.opener;
-                                    
+
                                     var cookie = opener.document.cookie;
-                                    
+
                                     var cookies = cookie.split(";");
                                     var layersList;
                                     for(var i=0; i<cookies.length; i++){
@@ -463,19 +462,19 @@
                                             layersList = cookies[i].split("=")[1];
                                         }
                                     }
-                                    
+
                                     if(layersList){
                                         var layers = layersList.split("#");
-                                
+
                                         for(var i=0; i<layers.length; i++){
                                             var keys = layers[i];
-                                            
+
                                             keys = unescape(keys);
                                             keys = Ext.util.JSON.decode(keys);
-                                            
+
                                             var lname = keys.layer;
                                             var lwms = decodeURIComponent(keys.wms);
-                                            
+
                                             addMSLayer(
                                                 lname,
                                                 lname,
@@ -485,7 +484,7 @@
                                     }
                                 }else{
                                     var title = layTitle ? layTitle : layName;
-                                    
+
                                     addMSLayer(
                                         title,
                                         layName,
@@ -498,10 +497,10 @@
                                      msg: "AddLayer plugin missing in configuration!",
                                      width: 300,
                                      icon: Ext.MessageBox.ALERT
-                                });  
+                                });
                             }
                         }
-                            
+
                         if(bbox){
                             app.mapPanel.map.zoomToExtent(bbox, true);
                         }
@@ -509,7 +508,7 @@
                 });
                 return app;
 			}
-			
+
 			var testSameOrigin = function (url) {
 				var loc = window.location,
 					a = document.createElement('a');
@@ -520,11 +519,11 @@
 					   a.port == loc.port &&
 					   a.protocol == loc.protocol;
 			}
-			
-			var loginService = testSameOrigin(serverConfig.geoStoreBase) ? serverConfig.geoStoreBase + 
-					"users/user/details?includeattributes=true" : proxy + encodeURIComponent(serverConfig.geoStoreBase 
+
+			var loginService = testSameOrigin(serverConfig.geoStoreBase) ? serverConfig.geoStoreBase +
+					"users/user/details?includeattributes=true" : proxy + encodeURIComponent(serverConfig.geoStoreBase
 						+ "users/user/details?includeattributes=true");
-			
+
 			var login = new gxp.plugins.GeoStoreLogin({
 				draggable:false,
 				closable: false,
@@ -535,20 +534,20 @@
 					this.authorizedRoles = ["ROLE_ADMINISTRATOR"];
 					Ext.getCmp('paneltbar').items.each(function(tool) {
 						if (tool.needsAuthorization === true) {
-							tool.enable();	
+							tool.enable();
 							tool.auth=login.token;
-						}           
+						}
 					},this);
-					
+
 					this.loginAction.disable();
 					this.loginAction.setHidden(true);
 					this.logoutAction.show();
 					this.logoutAction.enable();
 					this.logged = true;
-					
+
 					if(this.win){
 						this.win.close();
-					}				
+					}
 				},
 				loginSuccess: function(response){
 					if(login.user){
@@ -556,14 +555,14 @@
 							token: login.token,
 							user: login.user
 						};
-						
+
 						sessionStorage["userDetails"] = Ext.util.JSON.encode(uDetails);
                         window.location.reload();
 					}
 				},
 				showLogout : function(){
-					var logoutFunction = function(buttonId, text,opt){        
-						if(buttonId === 'ok'){ 						
+					var logoutFunction = function(buttonId, text,opt){
+						if(buttonId === 'ok'){
 							// Clear the sessionStorage
 							for(var i = 0; i < sessionStorage.length; i++) {
 								var key = sessionStorage.key(i);
@@ -575,7 +574,7 @@
 							location.reload();
 						}
 					}
-					
+
 					Ext.Msg.show({
 					   title: this.logoutTitle,
 					   msg: this.logoutText,
@@ -583,7 +582,7 @@
 					   fn: logoutFunction,
 					   icon: Ext.MessageBox.QUESTION,
 					   scope: this
-					});        
+					});
 				}
 			});
 
@@ -594,11 +593,32 @@
 
                 var userDetails = Ext.util.JSON.decode(sessionStorage["userDetails"]);
                 var isAdmin = false;
-
                 // get auth info
                 if (userDetails) {
                     var user = userDetails.user;
                     if(user){
+                        //Check if user as default_map attribute defined
+                        if(user.attribute && mapIdentifier == -1) {
+                                var defaultMap=null;
+                                var attributes=[];
+                             if(user.attribute instanceof Array)
+                                 attributes=user.attribute;
+                             else
+                                 attributes.push(user.attribute);
+                             for(var i = 0; i<attributes.length;i++) {
+                                 if(attributes[i].name=='default_map'){
+                                     defaultMap=attributes[i].value;
+                                     break;
+                                 }
+                             }
+                             if(defaultMap){
+                                    var newUrl = window.location.href;
+                                    newUrl += (window.location.search.length>0)? "&mapId="+defaultMap : "?mapId="+defaultMap;
+                                    //reload page with default map passed
+                                    window.location.replace(newUrl);
+                             }
+                         }
+
                         if(user.role && ["ROLE_ADMIN","ADMIN"].indexOf(user.role) > -1){
                             isAdmin = true;
                         }
@@ -618,7 +638,7 @@
                             }
                             */
                             if(serverConfig.restrictToGroups && serverConfig.redirectDeniedTo){
-                                
+
                                 if(!hasGroup(user, serverConfig.restrictToGroups)){
                                     window.location.replace(serverConfig.redirectDeniedTo);
                                 }
@@ -626,7 +646,7 @@
                         }
                     }
                 }
-                
+
                 initComposer();
 
                 app.on('ready',function(){
@@ -644,47 +664,47 @@
                      myAccount.addOutput();
                 });
             }
-			
+
 		   /**
-			* Add a WMS layer from GeoNetwork 
+			* Add a WMS layer from GeoNetwork
 			*
 			* TODO: Check the API using a MapServer URL as wmsURL.
 			*/
 			addMSLayer = function(msLayerTitle, msLayerName, wmsURL){
 				var addLayer = app.tools["addlayer"];
-				
+
 				var options = {
 					msLayerTitle: unescape(msLayerTitle),
 					msLayerName: unescape(msLayerName),
 					wmsURL: wmsURL
 				};
-				
+
 				addLayer.addLayer(
 					options
 				);
 			};
 	    };
-		
+
 	    // geostore base
 	    if(!serverConfig){
 	    	serverConfig = {};
 	    }
-		
+
         serverConfig = Ext.applyIf(serverConfig, localConfig);
 		serverConfig.geoStoreBaseURL = serverConfig.geoStoreBase || ('http://' + window.location.host + '/geostore/rest/');
 
 
 		// use GeoExplorerLoader to load configuration files
-		var loader = new GeoExplorerLoader(serverConfig, customConfigName || 'login', mapStoreDebug, mapIdentifier, 
+		var loader = new GeoExplorerLoader(serverConfig, customConfigName || 'login', mapStoreDebug, mapIdentifier,
 			authorization, fullScreen, templateId);
-		
+
 		loader.on("configfinished", function (config){
               //apply the loaded configuration.
               serverConfig = Ext.applyIf(serverConfig, config);
               proxy = mapStoreDebug === true ? "/proxy/?url=" : serverConfig.proxy;
-			  
+
               //ready to create GeoExplorer
               Ext.onReady(onReady);
-		});     
+		});
     </script>
 

--- a/mapcomposer/app/applications/he/templates/manager.html
+++ b/mapcomposer/app/applications/he/templates/manager.html
@@ -1,0 +1,209 @@
+<!DOCTYPE html>
+<html>
+    <head>
+    <!--meta http-equiv="X-UA-Compatible" content="IE=8" /-->
+    <title>Map Manager</title>
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+    <link rel="shortcut icon" href="theme/app/img/favicon.ico">
+
+     <!-- Ext resources -->
+    <link rel="stylesheet" type="text/css" href="externals/ext/resources/css/ext-all.css">
+    <link rel="stylesheet" type="text/css" href="externals/ext/resources/css/xtheme-gray.css">
+    <script type="text/javascript" src="externals/ext/adapter/ext/ext-base.js"></script>
+    <script type="text/javascript" src="externals/ext/ext-all.js"></script>
+
+    <!-- OpenLayers resources -->
+    <link rel="stylesheet" type="text/css" href="externals/openlayers/theme/default/style.css">
+    <script type="text/javascript" src="script/OpenLayers.js"></script>
+
+    <!-- Externatls OpenLayers libraries to manage other extensions -->
+    <script type="text/javascript" src="script/OpenLayersExt.js"></script>
+
+    <!-- Ask RingoJS for debug status -->
+    <script type="text/javascript" src="debug.js"></script>
+
+    <link rel="stylesheet" type="text/css" href="theme/app/openlayers.css" />
+
+    <!-- GeoExt resources -->
+    <link rel="stylesheet" type="text/css" href="externals/GeoExt/resources/css/popup.css">
+    <link rel="stylesheet" type="text/css" href="externals/GeoExt/resources/css/layerlegend.css">
+    <link rel="stylesheet" type="text/css" href="externals/GeoExt/resources/css/gxtheme-gray.css">
+    <script type="text/javascript" src="script/GeoExt.js"></script>
+
+    <!-- translation data  -->
+    <script type="text/javascript" src="externals/mapmanager/translations/en.js"></script>
+    <script type="text/javascript" src="externals/mapmanager/translations/fr.js"></script>
+    <script type="text/javascript" src="externals/mapmanager/translations/it.js"></script>
+    <script type="text/javascript" src="externals/mapmanager/translations/de.js"></script>
+    <script type="text/javascript" src="externals/mapmanager/translations/es.js"></script>
+    <!-- common scripts  -->
+    <script type="text/javascript" src="script/mapstoreCommon.js"></script>
+    <!-- MapStoreManager includes  -->
+    <script type="text/javascript" src="auth/base64.js"></script>
+    <link rel="stylesheet" type="text/css" href="externals/mapmanager/theme/css/mapstoremanager.css">
+    <script type="text/javascript" src="script/ux.js"></script>
+    <script type="text/javascript" src="script/mapmanager.js"></script>
+    <!-- QR Code -->
+    <script type="text/javascript" src="script/qrcodejs.js"></script>
+    <!-- common data  -->
+    <script type="text/javascript" src="config/common/localConfig.js"></script>
+
+    <script type="text/javascript" src="script/hemanager.js"></script>
+
+    <script>
+        // ///////////////////////////////////////////////////////////////
+        // Custom variables from the mapStoreConfig user configuration file
+        // ///////////////////////////////////////////////////////////////
+        var proxy;
+        var serverConfig;
+        var customConfigName;
+
+        // //////////////////////////////////////////////////
+        // Parsing the request to get the parameters
+        // //////////////////////////////////////////////////
+        var params = location.search.replace(/^\?/,'').replace(/&amp;/g,'&').split("&");
+        for (var j=0; j < params.length; j++) {
+            var param = params[j].split("=");
+            if(param[0]){
+                switch ( param[0] ) {
+                    case "mapId":
+                                    try {
+                                        mapIdentifier = parseInt(param[1]);
+                                    }catch(e){
+                                        mapIdentifier = -1;
+                                    }
+                                    break;
+                    case "bbox":
+                                    try{
+                                        bbox = new OpenLayers.Bounds.fromString(param[1]);
+                                    }catch(e){
+                                        bbox = undefined;
+                                    }
+                                    break;
+                    case "config":
+                                    customConfigName = param[1];
+                                    break;
+                    default :
+                                    //mapIdentifier = -1;
+                }
+            }
+        }
+
+        var onReady = function(){
+
+            config = serverConfig;
+            Ext.QuickTips.init();
+
+            var langData = config.locales;
+
+            var query = location.search;
+            if(query && query.substr(0,1) === "?"){
+                query = query.substring(1);
+            }
+
+            var url = Ext.urlDecode(query);
+            var code = url.locale;
+
+            if(!code){
+                code = config.defaultLanguage || config.locales[0][0];
+            }
+
+            var initialLanguageString;
+
+            //check if code is valid
+            if(code){
+                Ext.each(langData, function(rec){
+                    if(rec[0] === code.toLowerCase()){
+                        initialLanguageString = rec[1];
+                        return;
+                    }
+                });
+            }
+
+            if (GeoExt.Lang) {
+                    GeoExt.Lang.set(code);
+            }
+
+            // Apply config for lang selector
+            Ext.apply(config,{
+                langData: langData,
+                initialLanguageString: initialLanguageString,
+                lang: code || defaultLanguage || "en",
+                code: code
+            });
+            manager = new mxp.widgets.ManagerViewport({
+                layout:'border',
+                config: config,
+                items:{
+                    xtype: 'tabpanel',
+                    id:'mainTabPanel',
+                    items:[],
+                    enableTabScroll : true,
+                    activeTab:0
+
+                }
+            });
+        };
+
+        Ext.Ajax.request({
+              url: customConfigName ? "config/" + customConfigName + ".js"  : "config/managerConfig.js",
+              method: 'GET',
+              success: function(response, opts){
+
+                  try{
+                      serverConfig = Ext.util.JSON.decode(response.responseText);
+                  }catch(e){
+                      Ext.Msg.show({
+                            title: "Startup",
+                            msg: "An error occurred while parsing the external configuration: " + response.status,
+                            buttons: Ext.Msg.OK,
+                            icon: Ext.MessageBox.ERROR
+                      });
+                  }
+
+                  if(serverConfig){
+				      // ////////////////////////////////////////////////////////
+                      // Apply the local default configuration if not present.
+					  // ////////////////////////////////////////////////////////
+                      serverConfig = Ext.applyIf(serverConfig, localConfig);
+
+					  if(!serverConfig.geoStoreBase || serverConfig.geoStoreBase == ""){
+						serverConfig.geoStoreBase = 'http://' + window.location.host + '/geostore/rest/';
+					  }
+
+					  if(!serverConfig.composerUrl || serverConfig.composerUrl == ""){
+						serverConfig.composerUrl = "composer";
+					  }
+
+					  if(!serverConfig.socialUrl || serverConfig.socialUrl == ""){
+						serverConfig.socialUrl = 'http://' + window.location.host;
+					  }
+
+					  proxy = mapStoreDebug === true ? "/proxy/?url=" : serverConfig.proxy;
+                      serverConfig.proxy = proxy;
+
+                      OpenLayers.ProxyHost = this.proxy; // Explicit because this application doesn't include
+
+                      // ///////////////////////////////////////////////
+                      // Run the application when browser is ready
+                      // ///////////////////////////////////////////////
+                      Ext.onReady(onReady);
+                  }
+              },
+              failure:  function(response, opts){
+                  Ext.Msg.show({
+                        title: "Startup",
+                        msg: "An error occurred while getting the external configuration: " + response.status,
+                        buttons: Ext.Msg.OK,
+                        icon: Ext.MessageBox.ERROR
+                  });
+              }
+        });
+
+    </script>
+    </head>
+    <body>
+        <% render content %>
+		<div id="wrap" style="visibility:hidden"></div>
+    </body>
+</html>


### PR DESCRIPTION
Added the mapSelector.js plugin. It allows user to select and load a map between his  available maps (read permission) and  to save a map (write permission), to delete a map (write permission) and to create a new map (copy permission). The composer try to load default_map if defined in user attribute and if mapId isn't present in url request.
In manager app is possible to assign defaul_map to a user.
Advanced_users and admin are allowed to save,  create, delete and
load maps. Geoweb users are  only allowed to load maps