### PR TITLE
Fix #836 Possible to add a title and icon to collpased panel

### DIFF
--- a/mapcomposer/app/static/config/chartTest.js
+++ b/mapcomposer/app/static/config/chartTest.js
@@ -80,6 +80,7 @@
             "id": "south",
             "collapsedonfull": true,
             "region": "south",
+            "collapsedIconCls": "icon-south-panel",
             "split":true,
             "height": 330,
             "collapsed": true,
@@ -88,6 +89,7 @@
             "header": true,
             "hideMode": "offsets",
 			"floatable": false,
+            "plugins": ["Ext.ux.PanelCollapsedTitle"], 
             "items": [
 				{
 					"xtype": "container",
@@ -115,7 +117,9 @@
         },
         {
               "xtype": "panel",
-              "title": "Pannello Ricerche",  
+              "title": "Pannello Ricerche",
+              "plugins": ["Ext.ux.PanelCollapsedTitle"],
+              "collapsedIconCls": "icon-east-panel",
 			  "floatable": false,			  
               "border": false,
               "id": "east",

--- a/mapcomposer/app/static/externals/ext/ux/PanelCollapsedTitle.js
+++ b/mapcomposer/app/static/externals/ext/ux/PanelCollapsedTitle.js
@@ -1,0 +1,119 @@
+/**
+ * Plugin for the Ext.Panel class to support a collapsed header title
+ * Also implements vertical rotation for east and west border panels
+ *
+ * @author  Joeri Sebrechts <joeri at sebrechts.net>
+ * @version 1.1
+ * @date    January 11th, 2010
+ * @license http://www.gnu.org/licenses/lgpl-3.0.txt
+ */
+Ext.ns('Ext.ux');
+Ext.ux.PanelCollapsedTitle = (function() {
+  var rotatedCls = 'x-panel-header-rotated';
+  var supportsSVG = 
+    !!document.implementation.hasFeature("http://www.w3.org/TR/SVG11/feature#BasicStructure", "1.1");
+  var patchCollapsedElem = function() {
+    var verticalText = ((this.region == 'east') || (this.region == 'west'));    
+    var containerStyle = 'overflow: visible; padding: 0; border: none; background: none;';
+    // For vertical text, and for browsers that support SVG
+    // (Firefox, Chrome, Safari 3+, Opera 8+)
+    if (verticalText && supportsSVG) {
+      this.collapsedHeader = this.ownerCt.layout[this.region].getCollapsedEl().createChild({
+        tag: 'div',
+        style: 'position:relative;top:50%;transform:translateY(-50%);'
+      });
+      // embed svg code inside this container div
+      var SVGNS = 'http://www.w3.org/2000/svg';
+      var svg = document.createElementNS(SVGNS, 'svg');
+      this.collapsedHeader.dom.appendChild(svg);
+      svg.setAttribute('width', '100%');
+      svg.setAttribute('height', '100%');
+      var textContainer = document.createElementNS(SVGNS, 'text');
+      textContainer.setAttribute('x', 6);
+      textContainer.setAttribute('y', 1);
+      textContainer.setAttribute('transform', 'rotate(90 6 1)');
+      textContainer.setAttribute('class', 'x-panel-header ' + rotatedCls);
+      svg.appendChild(textContainer);
+      this.collapsedHeaderText = document.createTextNode(this.title);
+      textContainer.appendChild(this.collapsedHeaderText);
+      // set the style to override the unwanted aspects of the x-panel-header class
+      // also copy the x-panel-header "color" to "fill", to color the SVG text node
+      var color = Ext.fly(textContainer).getStyle('color');
+      textContainer.setAttribute('style', containerStyle + ';fill: ' + color + ';');            
+    // For horizontal text or IE
+    } else {
+      var titleElemStyle = 'position: relative;';
+      if (verticalText) {
+        // use writing-mode for vertical text
+        titleElemStyle += 
+          'white-space: nowrap; writing-mode: tb-rl; top: 1px; left: 3px;';
+      } else {
+        titleElemStyle += 'top: 2px;';
+        // margin-right to ensure no overlap with uncollapse button
+        containerStyle += 'padding-left:4px;margin-right:18px;text-align:center';
+      };
+      this.collapsedHeader = this.ownerCt.layout[this.region].getCollapsedEl().createChild({
+        tag: 'div',
+        // overrides x-panel-header to remove unwanted aspects
+        style: containerStyle,
+        cls: 'x-panel-header ' + rotatedCls,
+        html: '<span style="'+ titleElemStyle + '">'+this.title+'</span>'
+      });
+      this.collapsedHeaderText = this.collapsedHeader.first();
+    };
+    if (this.collapsedIconCls) this.setCollapsedIconClass(this.collapsedIconCls);
+  };
+  this.init = function(p) {
+    if (p.collapsible) {
+      var verticalText = ((p.region == 'east') || (p.region == 'west'));
+      // update the collapsed header title also
+      p.setTitle = Ext.Panel.prototype.setTitle.createSequence(function(t) {
+        if (this.rendered && this.collapsedHeaderText) {
+          // if the collapsed title element is regular html dom
+          if (this.collapsedHeaderText.dom) {
+            this.collapsedHeaderText.dom.innerHTML = t;
+          // or if this is an SVG text node
+          } else if (this.collapsedHeaderText.replaceData) {
+            this.collapsedHeaderText.nodeValue = t;
+          };
+        };
+      });
+      // update the collapsed icon class also
+      p.setCollapsedIconClass = function(cls) {
+        var old = this.collapsedIconCls;
+        this.collapsedIconCls = cls;
+        if(this.rendered && this.collapsedHeader){
+          var hd = this.collapsedHeader,
+          img = hd.child('img.x-panel-inline-icon');
+          // if an icon image is already shown, modify it or remove it
+          if(img) {
+            if (this.collapsedIconCls) {
+              Ext.fly(img).replaceClass(old, this.collapsedIconCls);
+            } else {
+              // remove img node if the icon class is removed
+              Ext.fly(img).remove();
+            };
+          // otherwise create the img for the icon
+          } else if (this.collapsedIconCls) {
+            Ext.DomHelper.insertBefore(hd.dom.firstChild, {
+              tag:'img', src: Ext.BLANK_IMAGE_URL, 
+              cls:'x-panel-inline-icon '+this.collapsedIconCls,
+              style: verticalText 
+                ? 'display: block; margin: 1px 2px;' 
+                : 'margin-top: 2px; margin-right: 4px'
+            });
+          };
+        };
+      };
+      p.on('render', function() {
+        if (this.ownerCt.rendered && this.ownerCt.layout.hasLayout) {
+          patchCollapsedElem.call(p);
+        } else {
+          // the panel's container first needs to render/layout its collapsed title bars
+          this.ownerCt.on('afterlayout', patchCollapsedElem, p, {single:true});
+        };
+      }, p);
+    }
+  };
+  return this;
+})();

--- a/mapcomposer/app/static/script/app/GeoExplorer.js
+++ b/mapcomposer/app/static/script/app/GeoExplorer.js
@@ -632,6 +632,13 @@ var GeoExplorer = Ext.extend(gxp.Viewer, {
 			var toPortal = [];
 			var pans = this.customPanels;
 			for (var i = 0; i < pans.length; i++){
+                if (pans[i].plugins) {
+                    var plugins = [];
+                    for (var j = 0; j < pans[i].plugins.length; j++) {
+                        plugins[j] = eval(pans[i].plugins[j]);
+                    }
+                    pans[i].plugins = plugins;
+                }
 				if(pans[i].target){
 					additionalPanels.push(pans[i]);					
 				}else{

--- a/mapcomposer/app/static/theme/app/mapstore.css
+++ b/mapcomposer/app/static/theme/app/mapstore.css
@@ -414,3 +414,12 @@ div#homelogos ul li a:hover {
     z-index : -1 !important;
     padding : 0px !important;
 }
+
+.icon-east-panel{
+    background-image: url(img/silk/find.png);
+}
+
+
+.icon-south-panel{
+    background-image: url(img/silk/grid_columns.png);
+}

--- a/mapcomposer/buildjs.cfg
+++ b/mapcomposer/buildjs.cfg
@@ -310,6 +310,7 @@ include =
 	ux/PagingToolbarResizer.js
     ux/MultiSelect.js
     ux/ItemSelector.js
+    ux/PanelCollapsedTitle.js
 
 [PrintPreview.js]
 root = app/static/externals/PrintPreview/lib/GeoExt.ux


### PR DESCRIPTION
{
              "xtype": "panel",
              "title": "Pannello Ricerche",
              **"plugins": ["Ext.ux.PanelCollapsedTitle"],
              "collapsedIconCls": "icon-east-panel",**
	      "floatable": false,
              "border": false,
              "id": "east",
              "width": 400,
              "height": 500,
              "region": "east",
              "layout": "fit",
              "collapsed": true,
              "split": true,
              "collapsible": true,
              "header": true,
              "collapsedonfull": true
}