### PR TITLE
Fixes #827, Snapping agent will reload layer geometries when layer content is updated

### DIFF
--- a/mapcomposer/app/static/externals/gxp/src/script/plugins/FeatureEditor.js
+++ b/mapcomposer/app/static/externals/gxp/src/script/plugins/FeatureEditor.js
@@ -352,6 +352,7 @@ gxp.plugins.FeatureEditor = Ext.extend(gxp.plugins.ClickableFeatures, {
                                 featureStore.on({
                                     write: {
                                         fn: function() {
+                                            snappingAgent && snappingAgent.reloadLayer();
                                             if (popup && popup.isVisible()) {
                                                 popup.enable();
                                             }


### PR DESCRIPTION
When a new feature is added, a feature is removed or edited the snapping agent will reload the layer content.

![anim](https://cloud.githubusercontent.com/assets/1590542/20017386/430d8070-a2bb-11e6-8a2e-97e6898855aa.gif)
